### PR TITLE
Removed CA=CA.*C operation in LCC algorithm

### DIFF
--- a/Source/Algorithm/LAGraph_lcc.c
+++ b/Source/Algorithm/LAGraph_lcc.c
@@ -170,10 +170,6 @@ GrB_Info LAGraph_lcc            // compute lcc for all nodes in A
         LAGraph_desc_otoo)) ;
     GrB_free (&AT) ;
 
-    // CA = CA.*C via element-wise multiplication
-    LAGRAPH_OK (GrB_eWiseMult (CA, NULL, NULL, GrB_TIMES_FP64, CA, C, NULL)) ;
-    GrB_free (&C) ;
-
     //--------------------------------------------------------------------------
     // Calculate LCC
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Removed the operation CA=CA.\*C.

Because the previous ([line 169](https://github.com/GraphBLAS/LAGraph/blob/e95ffebba0c6503ec1411577fb2f43c80385a7f2/Source/Algorithm/LAGraph_lcc.c#L169-L170)) CA<C> = C\*AT operation can be expanded into CA = (C\*AT).\*C, the standalone CA.*C operation is not needed.