### PR TITLE
PageRank2 refactor and fix

### DIFF
--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -486,10 +486,10 @@ GrB_Info LAGraph_pagerank       // GrB_SUCCESS or error condition
 
 GrB_Info LAGraph_pagerank2
 (
+    GrB_Vector *result,
     GrB_Matrix A,
     double dampening_factor,
-    unsigned long iteration_num,
-    GrB_Vector *result
+    unsigned long iteration_num
 ) ;
 
 GrB_Info LAGraph_tricount   // count # of triangles

--- a/Source/Algorithm/LAGraph_pagerank2.c
+++ b/Source/Algorithm/LAGraph_pagerank2.c
@@ -79,6 +79,7 @@ GrB_Info LAGraph_pagerank2(
     LAGRAPH_OK(GrB_Matrix_nrows(&n, A))
     GrB_Index nvals;
     LAGRAPH_OK(GrB_Matrix_nvals(&nvals, A))
+
     // Make a complement descriptor
 
     LAGRAPH_OK(GrB_Descriptor_new(&invmask_desc))
@@ -166,7 +167,7 @@ GrB_Info LAGraph_pagerank2(
 
         // Divide previous PageRank with number of outbound edges
         LAGRAPH_OK(GrB_eWiseMult_Vector_BinaryOp(
-           importance_vec,
+            importance_vec,
             nondangling_mask,
             GrB_NULL,
             GrB_DIV_FP64,

--- a/Source/Algorithm/LAGraph_pagerank2.c
+++ b/Source/Algorithm/LAGraph_pagerank2.c
@@ -32,6 +32,17 @@
 
 */
 
+// LAGraph_pagerank2: Alternative PageRank implementation using a real
+// semiring. Not to be confused with the dpagerank2.c algorithm, included
+// in the SuiteSparse:GrapBLAS demos.
+//
+// This algorithm follows the specification given in the LDBC Graphalytics
+// benchmark, see https://github.com/ldbc/ldbc_graphalytics_docs/
+//
+// Contributed by Gabor Szarnyas and Balint Hegyi, Budapest University of
+// Technology and Economics (with accented characters: G\'{a}bor Sz\'{a}rnyas
+// and B\'{a}lint Hegyi, using LaTeX syntax).
+
 #include "LAGraph.h"
 
 #define LAGRAPH_FREE_ALL { \
@@ -46,10 +57,10 @@
 };
 
 GrB_Info LAGraph_pagerank2(
+    GrB_Vector *result,
     GrB_Matrix A,
     double damping_factor,
-    unsigned long iteration_num,
-    GrB_Vector *result
+    unsigned long iteration_num
 ) {
     GrB_Info info;
     GrB_Index n;

--- a/Test/PageRank2/.gitignore
+++ b/Test/PageRank2/.gitignore
@@ -1,0 +1,7 @@
+# Ignore these files
+A.mtx
+stderr.txt
+w
+o
+v
+rg

--- a/Test/PageRank2/CMakeLists.txt
+++ b/Test/PageRank2/CMakeLists.txt
@@ -1,0 +1,213 @@
+#-------------------------------------------------------------------------------
+# LAGraph/Test/PageRank2/CMakeLists.txt:  cmake script for LAGraph test
+#-------------------------------------------------------------------------------
+
+# LAGraph, (... list all authors here) (c) 2019, All Rights Reserved.
+# http://lagraph.org  See LAGraph/LICENSE for license.
+
+# CMakeLists.txt: instructions for cmake to build LAGraph.
+# An ANSI C11 compiler is required.
+#
+# First, install any GraphBLAS library.
+# Alternatively, use ../GraphBLAS (see comments below).
+#
+# To compile and install the LAGraph library:
+#
+#   make
+#   sudo make install
+#
+# Then to compile and run the Demos:
+# 
+#   cd Demos
+#   make
+#
+# If that fails for any reason, make sure your compiler supports ANSI C11.  You
+# could try changing your compiler, for example:
+#
+#   cd build
+#   CC=icc cmake ..
+#   cd ..
+#   make
+#
+# Or, with other compilers:
+#
+#   CC=xlc cmake ..
+#   CC=gcc cmake ..
+#
+# To remove all compiled files and libraries (except installed ones):
+#
+#   make distclean
+
+#-------------------------------------------------------------------------------
+# get the version
+#-------------------------------------------------------------------------------
+
+# cmake 3.0 is preferred.
+cmake_minimum_required ( VERSION 2.8.12 )
+
+if ( CMAKE_VERSION VERSION_GREATER "3.0" )
+    cmake_policy ( SET CMP0042 NEW )
+    cmake_policy ( SET CMP0048 NEW )
+endif ( )
+
+project ( p2test )
+
+#-------------------------------------------------------------------------------
+# determine build type
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+# For development only, not for end-users:
+# set ( CMAKE_BUILD_TYPE Debug )
+
+if ( NOT CMAKE_BUILD_TYPE )
+    set ( CMAKE_BUILD_TYPE Release )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# edit these lines to select your GraphBLAS library
+#-------------------------------------------------------------------------------
+
+# link_directories ( /usr/local/lib )
+link_directories ( ../../../GraphBLAS/build )
+link_directories ( ../../build )
+
+# include_directories ( /usr/local/include )
+include_directories ( ../../../GraphBLAS/Include )
+include_directories ( ../../Include )
+
+#-------------------------------------------------------------------------------
+# determine what user threading model to use
+#-------------------------------------------------------------------------------
+
+include ( FindOpenMP  )
+include ( FindThreads )
+
+#-------------------------------------------------------------------------------
+# report status
+#-------------------------------------------------------------------------------
+
+message ( STATUS "CMAKE build type:          " ${CMAKE_BUILD_TYPE} )
+
+if ( ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message ( STATUS "CMAKE C Flags debug:       " ${CMAKE_C_FLAGS_DEBUG} )
+else ( )
+    message ( STATUS "CMAKE C Flags release:     " ${CMAKE_C_FLAGS_RELEASE} )
+endif ( )
+
+message ( STATUS "CMAKE compiler ID:         " ${CMAKE_C_COMPILER_ID} )
+message ( STATUS "CMAKE thread library:      " ${CMAKE_THREAD_LIBS_INIT} )
+message ( STATUS "CMAKE have pthreads:       " ${CMAKE_USE_PTHREADS_INIT}  )
+message ( STATUS "CMAKE have Win32 pthreads: " ${CMAKE_USE_WIN32_THREADS_INIT} )
+message ( STATUS "CMAKE have OpenMP:         " ${OPENMP_FOUND} )
+
+#-------------------------------------------------------------------------------
+# include directories
+#-------------------------------------------------------------------------------
+
+set ( CMAKE_INCLUDE_CURRENT_DIR ON )
+
+#-------------------------------------------------------------------------------
+# compiler options
+#-------------------------------------------------------------------------------
+
+# check which compiler is being used.  If you need to make
+# compiler-specific modifications, here is the place to do it.
+if ( "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    # cmake 2.8 workaround: gcc needs to be told to do ANSI C11.
+    # cmake 3.0 doesn't have this problem.
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -std=c11 -lm -Wno-pragmas " )
+    # check all warnings:
+#   set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -Werror " )
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 4.9 )
+        message ( FATAL_ERROR "gcc version must be at least 4.9" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Intel" )
+    # options for icc: also needs -std=c11
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -g -std=c11 " )
+    # check all warnings:
+#   set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -w3 " )
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 18.0 )
+        message ( FATAL_ERROR "icc version must be at least 18.0" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
+    # options for clang
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 3.3 )
+        message ( FATAL_ERROR "clang version must be at least 3.3" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" )
+    # options for MicroSoft Visual Studio
+endif ( )
+
+if ( ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}" )
+else ( )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}" )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# select the threading library 
+#-------------------------------------------------------------------------------
+
+if ( USER_OPENMP )
+    # user insists on OpenMP synchronization inside LAGraph
+    message ( STATUS "cmake -DUSER_OPENMP=1: insisting on using OpenMP" )
+    set ( USE_OPENMP true )
+elseif ( USER_POSIX )
+    # user insists on POSIX synchronization inside LAGraph
+    message ( STATUS "cmake -DUSER_POSIX=1: insisting on using POSIX" )
+    set ( USE_POSIX true )
+elseif ( USER_NONE )
+    message ( STATUS "cmake -DUSER_NONE=1: insisting on using no threading" )
+    set ( USE_NONE true )
+else ( )
+    # default: automatic selection
+    message ( STATUS "Automatic selection of synchronization method" )
+    if ( OPENMP_FOUND )
+        set ( USE_OPENMP true )
+    elseif ( CMAKE_USE_PTHREADS_INIT )
+        set ( USE_POSIX true )
+    endif ( )
+endif ( )
+
+# add the threading library
+if ( USE_OPENMP )
+    # use OpenMP
+    message ( STATUS "Using OpenMP to synchronize user threads" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -DUSER_OPENMP_THREADS " )
+elseif ( USE_POSIX )
+    # use POSIX
+    message ( STATUS "Using POSIX pthreads to synchronize user threads" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -pthread -DUSER_POSIX_THREADS " )
+else ( )
+    # use no threading at all
+    message ( WARNING "No support for user threads; LAGraph will not be thread-safe" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DUSER_NO_THREADS " )
+endif ( )
+
+if ( CMAKE_USE_PTHREADS_INIT )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_PTHREADS " )
+endif ( )
+
+if ( CMAKE_USE_WIN32_THREADS_INIT )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_WINDOWS_THREADS " )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# print final C flags
+#-------------------------------------------------------------------------------
+
+message ( STATUS "CMAKE C flags: " ${CMAKE_C_FLAGS} )
+
+#-------------------------------------------------------------------------------
+# Demo programs
+#-------------------------------------------------------------------------------
+
+file ( GLOB SOURCES "*.c" )
+
+add_executable ( p2test ${SOURCES} )
+
+# Libraries required for Demo programs
+target_link_libraries ( p2test graphblas lagraph m )
+

--- a/Test/PageRank2/Makefile
+++ b/Test/PageRank2/Makefile
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------
+# Test/PageRank/Makefile
+#-------------------------------------------------------------------------------
+
+# LAGraph, (... list all authors here) (c) 2019, All Rights Reserved.
+# http://graphblas.org  See LAGraph/LICENSE for license.
+
+#-------------------------------------------------------------------------------
+
+# simple Makefile for LAGraph/Test/PageRank/p2test,
+
+# relies on cmake to do the actual build.  Use the CMAKE_OPTIONS argument to
+# this Makefile to pass options to cmake.
+
+# Install LAGraph and GraphBLAS before trying to compile LAGraph.
+
+JOBS ?= 1
+
+# build and run test
+default: compile
+	./build/p2test < ../BFS/cover.mtx
+	./build/p2test < ../BFS/west0067.mtx
+
+# build test
+compile:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) --jobs=$(JOBS) )
+
+# just run cmake; do not compile
+cmake:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; )
+
+clean: distclean
+
+purge: distclean
+
+# remove all files not in the distribution
+distclean:
+	rm -rf build/* A.mtx p2test
+

--- a/Test/PageRank2/Makefile
+++ b/Test/PageRank2/Makefile
@@ -18,8 +18,9 @@ JOBS ?= 1
 
 # build and run test
 default: compile
-	./build/p2test < ../BFS/cover.mtx
-	./build/p2test < ../BFS/west0067.mtx
+	./build/p2test < ldbc-directed-example-unweighted.mtx
+#	./build/p2test < ../BFS/cover.mtx
+#	./build/p2test < ../BFS/west0067.mtx
 
 # build test
 compile:

--- a/Test/PageRank2/build/.gitignore
+++ b/Test/PageRank2/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files here except this file.
+*
+*/
+!.gitignore

--- a/Test/PageRank2/ldbc-directed-example-unweighted.mtx
+++ b/Test/PageRank2/ldbc-directed-example-unweighted.mtx
@@ -1,0 +1,20 @@
+%%MatrixMarket matrix coordinate integer general
+%%GraphBLAS GrB_BOOL
+10 10 17
+1 3 1
+1 5 1
+2 4 1
+2 5 1
+2 10 1
+3 1 1
+3 5 1
+3 8 1
+3 10 1
+5 3 1
+5 4 1
+5 8 1
+6 3 1
+6 4 1
+7 4 1
+8 1 1
+9 4 1

--- a/Test/PageRank2/p2test.c
+++ b/Test/PageRank2/p2test.c
@@ -55,7 +55,7 @@ int main ( )
     GrB_Matrix A = NULL ;
     GrB_Matrix Abool = NULL ;
     LAGraph_PageRank *P = NULL ;
-    GrB_Vector *PR = NULL;
+    GrB_Vector PR = NULL;
 
     LAGRAPH_OK (LAGraph_init ( )) ;
 
@@ -138,13 +138,13 @@ int main ( )
     // print results
     //--------------------------------------------------------------------------
 
-    GxB_Vector_fprint(PR, "---- PR ------", GxB_SHORT, stderr);
     /*
     for (int64_t k = 0 ; k < n ; k++)
     {
         printf ("%" PRIu64 " %g\n", P [k].page, P [k].pagerank) ;
     }
     */
+    GxB_Vector_fprint(PR, "---- PR ------", GxB_SHORT, stderr);
 
     //--------------------------------------------------------------------------
     // free all workspace and finish

--- a/Test/PageRank2/p2test.c
+++ b/Test/PageRank2/p2test.c
@@ -1,0 +1,153 @@
+//------------------------------------------------------------------------------
+// ptest: read in (or create) a matrix and test PageRank
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// Contributed by Tim Davis, Texas A&M and Gabor Szarnyas, BME
+
+// usage:
+// ptest < in > out
+
+#include "LAGraph.h"
+
+#define LAGRAPH_FREE_ALL                        \
+{                                               \
+    if (P != NULL) { free (P) ; P = NULL ; }    \
+    GrB_free (&A) ;                             \
+    GrB_free (&Abool) ;                         \
+}
+
+int main ( )
+{
+
+    GrB_Info info ;
+    GrB_Matrix A = NULL ;
+    GrB_Matrix Abool = NULL ;
+    LAGraph_PageRank *P = NULL ;
+
+    LAGRAPH_OK (LAGraph_init ( )) ;
+
+    int nthreads_max = LAGraph_get_nthreads ( ) ;
+    LAGraph_set_nthreads (1) ;
+
+    //--------------------------------------------------------------------------
+    // read in a matrix from a file and convert to boolean
+    //--------------------------------------------------------------------------
+
+    // read in the file in Matrix Market format
+    LAGRAPH_OK (LAGraph_mmread (&A, stdin)) ;
+    // GxB_fprint (A, GxB_COMPLETE, stderr) ;
+    // LAGraph_mmwrite (A, stderr) ;
+
+    // convert to boolean, pattern-only
+    LAGRAPH_OK (LAGraph_pattern (&Abool, A)) ;
+    // LAGraph_mmwrite (Abool, stderr) ;
+    GrB_free (&A) ;
+    A = Abool ;
+    Abool = NULL ;
+    // GxB_fprint (A, GxB_COMPLETE, stderr) ;
+
+    // finish any pending computations
+    GrB_Index nvals ;
+    GrB_Matrix_nvals (&nvals, A) ;
+
+    //--------------------------------------------------------------------------
+    // get the size of the problem.
+    //--------------------------------------------------------------------------
+
+    GrB_Index nrows, ncols ;
+    LAGRAPH_OK (GrB_Matrix_nrows (&nrows, A)) ;
+    LAGRAPH_OK (GrB_Matrix_ncols (&ncols, A)) ;
+    GrB_Index n = nrows ;
+
+    // GxB_fprint (A, GxB_COMPLETE, stderr) ;
+
+    // LAGRAPH_OK (GrB_Matrix_setElement (A, 0, 0, n-1)) ;     // hack
+
+    fprintf (stderr, "\n=========="
+        "input graph: nodes: %"PRIu64" edges: %"PRIu64"\n", n, nvals) ;
+
+    //--------------------------------------------------------------------------
+    // compute the pagerank
+    //--------------------------------------------------------------------------
+
+    int ntrials = 1 ;       // increase this to 10, 100, whatever, for more
+                            // accurate timing
+
+    double tol = 1e-5 ;
+    int iters, itermax = 100 ;
+
+    int nthread_list [7] = {1, 2, 4, 8, 16, 20, 40} ;
+
+    // for (int nthreads = 1 ; nthreads <= nthreads_max ; nthreads *= 2)
+    for (int kk = 0 ; kk < 7 ; kk++)
+    {
+        int nthreads = nthread_list [kk] ;
+        LAGraph_set_nthreads (nthreads) ;
+
+        // start the timer
+        double tic [2] ;
+        LAGraph_tic (tic) ;
+
+        for (int trial = 0 ; trial < ntrials ; trial++)
+        {
+            if (P != NULL) { free (P) ; P = NULL ; }
+            LAGRAPH_OK (LAGraph_pagerank2 (&P, A, 0.85, itermax)) ;
+        }
+
+        // stop the timer
+        double t1 = LAGraph_toc (tic) / ntrials ;
+        fprintf (stderr, "pagerank  time: %12.6e (sec), "
+            "rate: %g (1e6 edges/sec) iters: %d threads: %d\n",
+            t1, 1e-6*((double) nvals) / t1, iters, nthreads) ;
+    }
+
+    //--------------------------------------------------------------------------
+    // print results
+    //--------------------------------------------------------------------------
+
+    for (int64_t k = 0 ; k < n ; k++)
+    {
+        printf ("%" PRIu64 " %g\n", P [k].page, P [k].pagerank) ;
+    }
+
+    //--------------------------------------------------------------------------
+    // free all workspace and finish
+    //--------------------------------------------------------------------------
+
+    LAGRAPH_FREE_ALL ;
+    LAGRAPH_OK (LAGraph_finalize ( )) ;
+    return (GrB_SUCCESS) ;
+}
+

--- a/Test/PageRank2/p2test.c
+++ b/Test/PageRank2/p2test.c
@@ -55,6 +55,7 @@ int main ( )
     GrB_Matrix A = NULL ;
     GrB_Matrix Abool = NULL ;
     LAGraph_PageRank *P = NULL ;
+    GrB_Vector *PR = NULL;
 
     LAGRAPH_OK (LAGraph_init ( )) ;
 
@@ -122,8 +123,8 @@ int main ( )
 
         for (int trial = 0 ; trial < ntrials ; trial++)
         {
-            if (P != NULL) { free (P) ; P = NULL ; }
-            LAGRAPH_OK (LAGraph_pagerank2 (&P, A, 0.85, itermax)) ;
+            if (PR != NULL) { free (PR) ; PR = NULL ; }
+            LAGRAPH_OK (LAGraph_pagerank2 (&PR, A, 0.85, itermax)) ;
         }
 
         // stop the timer
@@ -137,10 +138,13 @@ int main ( )
     // print results
     //--------------------------------------------------------------------------
 
+    GxB_Vector_fprint(PR, "---- PR ------", GxB_SHORT, stderr);
+    /*
     for (int64_t k = 0 ; k < n ; k++)
     {
         printf ("%" PRIu64 " %g\n", P [k].page, P [k].pagerank) ;
     }
+    */
 
     //--------------------------------------------------------------------------
     // free all workspace and finish


### PR DESCRIPTION
Many changes for PageRank2:

* add comment to explain that `dpagerank2` is a different algorithm
* update/improve comments
* swap arguments of `LAGraph_pagerank2` so that it follows the LAGraph convention of putting the output to the first argument
* rename some variables
* simplify PR maintenance: drop `pr_prev` and `pr_next` in favor of a single `pr` vector
* return `GrB_success`
* fix incorrect application of `nondangling_mask` for importance calculations
* add test source file based on `ptest.c`