### PR TITLE
Optimize LCC algorithm

### DIFF
--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -174,8 +174,9 @@ extern GrB_UnaryOp
     LAGraph_DECR_INT32          ,
     LAGraph_DECR_INT64          ,
 
-    // unary operator for lcc
-    LAGraph_COMB_FP64           ,
+    // unary operators for lcc
+    LAGraph_COMB_DIR_FP64       ,
+    LAGraph_COMB_UNDIR_FP64     ,
 
     // unary ops to check if greater than zero
     LAGraph_GT0_FP32            ,
@@ -542,6 +543,7 @@ GrB_Info LAGraph_lcc            // compute lcc for all nodes in A
 (
     GrB_Vector *LCC_handle,     // output vector
     const GrB_Matrix A,         // input matrix
+    bool symmetric,             // if true, the matrix is symmetric
     bool sanitize,              // if true, ensure A is binary
     double t [2]                // t [0] = sanitize time, t [1] = lcc time,
                                 // in seconds

--- a/Source/Algorithm/LAGraph_lcc.c
+++ b/Source/Algorithm/LAGraph_lcc.c
@@ -59,12 +59,16 @@
 // Then the metric lcc(v) is defined as:
 
 // lcc(v) = (sum for all u in N(v) of |intersection (N(v), N_out(u))) /
-//          ( |N(v)| * (|N(v)|-1))
+//          ( |N(v)| * (|N(v)|-1) )
 
 // That is, for directed graphs, the set of neighbors N(v) is found without
 // taking directions into account, but a node u that has both an edge (u,v) and
-// (v,u) is counted just once.  However, edges directions are enforced when
-// considering two nodes u1 and u2 that are both in N(v).
+// (v,u) is counted just once.  However, edge directions are enforced when
+// considering two nodes u1 and u2 that are both in N(v), i.e. when counting
+// the number of edges between neighbors, (u,v) and (v,u) are counted as two.
+// To account for this, the maximum possible number of edges for vertex v is
+// determined as the 2-combination of |N(v)| for undirected graphs and as the
+// 2-permutation of |N(v)| for directed graphs.
 
 // The input matrix A must be square.  If A is known to be binary (with all
 // explicit edge weights equal to 1), then sanitize can be false.  This is the
@@ -157,7 +161,7 @@ GrB_Info LAGraph_lcc            // compute lcc for all nodes in A
         S = NULL ;
 
         //--------------------------------------------------------------------------
-        // L = tril(A)
+        // L = tril(C)
         //--------------------------------------------------------------------------
         LAGRAPH_OK (GxB_select (L, NULL, NULL, GxB_TRIL, C, NULL, NULL)) ;
     }

--- a/Source/Algorithm/LAGraph_lcc.c
+++ b/Source/Algorithm/LAGraph_lcc.c
@@ -86,7 +86,6 @@
     GrB_free (&LCC) ;               \
     if (sanitize) GrB_free (&S) ;   \
     GrB_free (&C) ;                 \
-    GrB_free (&M) ;                 \
     GrB_free (&CL) ;                \
     GrB_free (&W) ;                 \
 }
@@ -113,7 +112,7 @@ GrB_Info LAGraph_lcc            // compute lcc for all nodes in A
         return (GrB_NULL_POINTER) ;
     }
 
-    GrB_Matrix C = NULL, CL = NULL, S = NULL, M = NULL, L = NULL ;
+    GrB_Matrix C = NULL, CL = NULL, S = NULL, L = NULL ;
     GrB_Vector W = NULL, LCC = NULL ;
     GrB_Info info ;
 

--- a/Source/Utility/LAGraph_alloc_global.c
+++ b/Source/Utility/LAGraph_alloc_global.c
@@ -401,8 +401,8 @@ void LAGraph_decr_int64
 }
 
 // z = x * (x - 1), used by LAGraph_lcc.
-// This operator calculates the comb(d(v), 2) / 2 value.
-void LAGraph_comb_fp64
+// This operator calculates the 2-permutation of d(v).
+void LAGraph_comb_dir_fp64
 (
     void *z,
     const void *x
@@ -413,7 +413,22 @@ void LAGraph_comb_fp64
     (*zd) = ((xd) * (xd - 1)) ;
 }
 
-GrB_UnaryOp LAGraph_COMB_FP64 = NULL ;
+// z = x * (x - 1) / 2, used by LAGraph_lcc.
+// This operator calculates the 2-combination of d(v).
+void LAGraph_comb_undir_fp64
+(
+    void *z,
+    const void *x
+)
+{
+    double xd = *(double *) x ;
+    double *zd = (double *) z ;
+    (*zd) = ((xd) * (xd - 1)) / 2;
+}
+
+
+GrB_UnaryOp LAGraph_COMB_DIR_FP64 = NULL ;
+GrB_UnaryOp LAGraph_COMB_UNDIR_FP64 = NULL ;
 
 // monoids
 GrB_Monoid LAGraph_PLUS_INT64_MONOID = NULL ;
@@ -682,11 +697,15 @@ GrB_Info LAGraph_alloc_global ( )
     #endif
 
     //--------------------------------------------------------------------------
-    // create the comb operator for LAGraph_lcc
+    // create the operators for LAGraph_lcc
     //--------------------------------------------------------------------------
 
-    LAGRAPH_OK (GrB_UnaryOp_new (&LAGraph_COMB_FP64,
-        F_UNARY (LAGraph_comb_fp64),
+    LAGRAPH_OK (GrB_UnaryOp_new (&LAGraph_COMB_DIR_FP64,
+        F_UNARY (LAGraph_comb_dir_fp64),
+        GrB_FP64, GrB_FP64)) ;
+
+    LAGRAPH_OK (GrB_UnaryOp_new (&LAGraph_COMB_UNDIR_FP64,
+        F_UNARY (LAGraph_comb_undir_fp64),
         GrB_FP64, GrB_FP64)) ;
 
     //--------------------------------------------------------------------------

--- a/Source/Utility/LAGraph_free_global.c
+++ b/Source/Utility/LAGraph_free_global.c
@@ -67,7 +67,8 @@ GrB_Info LAGraph_free_global ( )
     GrB_free (&LAGraph_TRUE_BOOL_Complex) ;
     GrB_free (&LAGraph_ONE_FP64) ;
     GrB_free (&LAGraph_ONE_UINT32) ;
-    GrB_free (&LAGraph_COMB_FP64) ;
+    GrB_free (&LAGraph_COMB_DIR_FP64) ;
+    GrB_free (&LAGraph_COMB_UNDIR_FP64) ;
     GrB_free (&LAGraph_GT0_FP32) ;
     GrB_free (&LAGraph_GT0_FP64) ;
     GrB_free (&LAGraph_YMAX_FP32) ;

--- a/Test/LCC/Makefile
+++ b/Test/LCC/Makefile
@@ -18,7 +18,9 @@ JOBS ?= 1
 
 # build and run test
 default: compile
-	./build/lcctest < ../BFS/west0067.mtx
+	./build/lcctest ../BFS/west0067.mtx 0
+	./build/lcctest ldbc-directed-example.mtx 0
+	./build/lcctest ldbc-undirected-example.mtx 1
 
 # build test
 compile:

--- a/Test/LCC/lcctest.c
+++ b/Test/LCC/lcctest.c
@@ -72,9 +72,11 @@ int main (int argc, char **argv)
     FILE *out = stdout ;
 
     FILE *f ;
-    if (argc == 1)
+    bool symmetric ;
+    if (argc < 3)
     {
         f = stdin ;
+        symmetric = false ;
     }
     else
     {
@@ -84,7 +86,9 @@ int main (int argc, char **argv)
             printf ("unable to open file [%s]\n", argv[1]) ;
             return (GrB_INVALID_VALUE) ;
         }
+        symmetric = argv[2] == 0 ;
     }
+
     LAGRAPH_OK (LAGraph_mmread (&C, f)) ;
     GrB_Index n, ne ;
     LAGRAPH_OK (GrB_Matrix_nrows (&n, C)) ;
@@ -148,9 +152,9 @@ int main (int argc, char **argv)
         LAGraph_set_nthreads (nthreads) ;
 
         // ignore the sanitize time;  assume the user could have provided an
-        // input graph that is already undirected with no self-edges
+        // input graph that is already binary with no self-edges
         double timing [2] ;
-        LAGRAPH_OK (LAGraph_lcc (&LCC, A, true, timing)) ;
+        LAGRAPH_OK (LAGraph_lcc (&LCC, A, symmetric, true, timing)) ;
         double t = timing [1] ;
 
         if (LCC1 == NULL)

--- a/Test/LCC/ldbc-directed-example.mtx
+++ b/Test/LCC/ldbc-directed-example.mtx
@@ -1,0 +1,20 @@
+%%MatrixMarket matrix coordinate integer general
+%%GraphBLAS GrB_BOOL
+10 10 17
+1 3 1
+1 5 1
+2 4 1
+2 5 1
+2 10 1
+3 1 1
+3 5 1
+3 8 1
+3 10 1
+5 3 1
+5 4 1
+5 8 1
+6 3 1
+6 4 1
+7 4 1
+8 1 1
+9 4 1

--- a/Test/LCC/ldbc-undirected-example.mtx
+++ b/Test/LCC/ldbc-undirected-example.mtx
@@ -1,0 +1,15 @@
+%%MatrixMarket matrix coordinate integer symmetric
+%%GraphBLAS GrB_BOOL
+9 9 12
+1 2 1
+1 3 1
+2 3 1
+2 4 1
+2 7 1
+4 5 1
+4 7 1
+5 6 1
+5 7 1
+5 8 1
+5 9 1
+6 8 1


### PR DESCRIPTION
Optimize LCC based on the observation that the lower triangle of `A+A'` (defined on a real semiring), i.e. `L = tril(A+A')`, is sufficient to compute the number of triangles for each vertex and results in significantly more spares matrices. Using this, instead of `CA<C>=C*A` we now compute `CL<C>=C*L`.

The code now distinguishes between symmetric and unsymmetric matrices (corresponding to undirected and directed graphs, respectively) as they need to be treated differently when determining the maximum possible number of edges between neighbors.