### PR TITLE
Fix memory management in CDLP algorithm

### DIFF
--- a/Source/Algorithm/LAGraph_cdlp.c
+++ b/Source/Algorithm/LAGraph_cdlp.c
@@ -142,8 +142,8 @@
 #define LAGRAPH_FREE_ALL                                                       \
 {                                                                              \
     GrB_free (&L) ;                                                            \
+    GrB_free (&L_prev) ;                                                       \
     if (sanitize) GrB_free (&S) ;                                              \
-    GrB_free (&S) ;                                                            \
     GrB_free (&AL_in) ;                                                        \
     GrB_free (&AL_out) ;                                                       \
     GrB_free (&desc_in) ;                                                      \
@@ -235,7 +235,6 @@ GrB_Info LAGraph_cdlp
     LAGRAPH_OK(GrB_Descriptor_set(desc_out, GrB_INP0, GrB_TRAN))
     LAGRAPH_OK(GrB_Descriptor_set(desc_out, GrB_OUTP, GrB_REPLACE))
 
-
     // n = size of A (# of nodes in the graph)
     GrB_Index n;
     LAGRAPH_OK (GrB_Matrix_nrows(&n, A))
@@ -273,8 +272,8 @@ GrB_Info LAGraph_cdlp
     I = LAGraph_malloc(nnz, sizeof(GrB_Index));
     X = LAGraph_malloc(nnz, sizeof(GrB_Index));
 
-    uint64_t* workspace1 = LAGraph_malloc(nnz, sizeof(GrB_Index));
-    uint64_t* workspace2 = LAGraph_malloc(nnz, sizeof(GrB_Index));
+    uint64_t *workspace1 = LAGraph_malloc(nnz, sizeof(GrB_Index));
+    uint64_t *workspace2 = LAGraph_malloc(nnz, sizeof(GrB_Index));
 
     const int nthreads = LAGraph_get_nthreads();
     for (int iteration = 0; iteration < itermax; iteration++)
@@ -348,6 +347,11 @@ GrB_Info LAGraph_cdlp
             }
         }
     }
+
+    LAGRAPH_FREE (I) ;
+    LAGRAPH_FREE (X) ;
+    LAGRAPH_FREE (workspace1) ;
+    LAGRAPH_FREE (workspace2) ;
 
     //--------------------------------------------------------------------------
     // extract final labels to the result vector


### PR DESCRIPTION
During my experiments on a 500GB RAM machine, the CDLP algorithm ran out of memory on the Graph500-28 graph (121M vertices, 4.2B edges). I looked into the code and fixed some memory management issues but didn't found anything excessive.

How could one reduce the memory consumption of this algorithm?