### PR TITLE
TC, BFS and CC able to read binary + gap test

### DIFF
--- a/Test/BFS/2ndJan.out
+++ b/Test/BFS/2ndJan.out
@@ -1,0 +1,377 @@
+
+  50636151x50636151 GraphBLAS bool matrix, sparse by row:
+  A, 1930292948 entries
+
+    (10,49817219)   1
+    (10,49824797)   1
+    (10,49824842)   1
+    (10,49824843)   1
+    (10,49824846)   1
+    (10,49826026)   1
+    (10,49826027)   1
+    (10,49826709)   1
+    (10,49826710)   1
+    (10,49826711)   1
+    (10,49826712)   1
+    (10,49826713)   1
+    (10,49826714)   1
+    (10,49826715)   1
+    (10,49826716)   1
+    (10,49826717)   1
+    (10,49826719)   1
+    (10,49827761)   1
+    (10,49853332)   1
+    (10,49853570)   1
+    (10,49853571)   1
+    (10,49853572)   1
+    (10,49853573)   1
+    (10,49853574)   1
+    (10,49853575)   1
+    (10,49855627)   1
+    (10,50184826)   1
+    (10,50284715)   1
+    (10,50284718)   1
+    (10,50284719)   1
+    ...
+
+==========input graph: nodes: 50636151 edges: 1930292948 source node: 0
+ nthreads: 40
+simple    time: 4.467967e-01 (sec), rate: 4320.29 (1e6 edges/sec)
+transpose time: 5.5644
+
+nthreads  1 push/pull: (no tree) 5.868379e+00 (sec),  rate: 328.931 (1e6 edges/sec)
+nthreads  2 push/pull: (no tree) 3.051171e+00 (sec),  rate: 632.64 (1e6 edges/sec)
+speedup 1.92332
+nthreads  4 push/pull: (no tree) 1.626864e+00 (sec),  rate: 1186.51 (1e6 edges/sec)
+speedup 3.60717
+nthreads  8 push/pull: (no tree) 9.200858e-01 (sec),  rate: 2097.95 (1e6 edges/sec)
+speedup 6.37808
+nthreads 16 push/pull: (no tree) 5.575780e-01 (sec),  rate: 3461.92 (1e6 edges/sec)
+speedup 10.5248
+nthreads 32 push/pull: (no tree) 4.481427e-01 (sec),  rate: 4307.32 (1e6 edges/sec)
+speedup 13.0949
+
+parallel (with tree):
+nthreads  1 push/pull (w/ tree): 7.048787e+00 (sec),  rate: 273.848 (1e6 edges/sec)
+nthreads  2 push/pull (w/ tree): 3.698263e+00 (sec),  rate: 521.946 (1e6 edges/sec)
+speedup 1.90597
+nthreads  4 push/pull (w/ tree): 1.991465e+00 (sec),  rate: 969.283 (1e6 edges/sec)
+speedup 3.5395
+nthreads  8 push/pull (w/ tree): 1.142209e+00 (sec),  rate: 1689.96 (1e6 edges/sec)
+speedup 6.17119
+nthreads 16 push/pull (w/ tree): 7.102505e-01 (sec),  rate: 2717.76 (1e6 edges/sec)
+speedup 9.92437
+nthreads 32 push/pull (w/ tree): 5.823623e-01 (sec),  rate: 3314.59 (1e6 edges/sec)
+speedup 12.1038
+
+v starts sparse: (nthread 40)
+pushpull sparse 2.704253e-04 (sec), rate: 7.13799e+06 (1e6 edges/sec)
+number of levels: 1 (for s = 0, single-source)
+# nodes visited (for single-source): 1 out of 50636151 (1.97487e-06 % of the graph)
+bfs_test: all tests passed
+------------------------------------------------------------
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+nthreads for simple BFS: 40
+
+  134217726x134217726 GraphBLAS bool matrix, sparse by row:
+  A, 4223264644 entries
+
+    (1,83111928)   1
+    (2,113772338)   1
+    (9,26920261)   1
+    (9,33335674)   1
+    (9,90905511)   1
+    (9,92964069)   1
+    (9,126874301)   1
+    (11,3075467)   1
+    (11,11283179)   1
+    (11,14136330)   1
+    (11,18241662)   1
+    (11,21256905)   1
+    (11,26197037)   1
+    (11,34992956)   1
+    (11,49762924)   1
+    (11,54231301)   1
+    (11,55275316)   1
+    (11,55896288)   1
+    (11,56613538)   1
+    (11,69378808)   1
+    (11,76391974)   1
+    (11,77970070)   1
+    (11,80121717)   1
+    (11,113872174)   1
+    (11,115829864)   1
+    (11,125066355)   1
+    (11,129708509)   1
+    (11,131285585)   1
+    (11,132549336)   1
+    (14,11049596)   1
+    ...
+
+==========input graph: nodes: 134217726 edges: 4223264644 source node: 0
+ nthreads: 40
+simple    time: 1.350996e+00 (sec), rate: 3126.04 (1e6 edges/sec)
+transpose time: 67.3427
+
+nthreads  1 push/pull: (no tree) 1.680926e+01 (sec),  rate: 251.246 (1e6 edges/sec)
+nthreads  2 push/pull: (no tree) 8.325557e+00 (sec),  rate: 507.265 (1e6 edges/sec)
+speedup 2.019
+nthreads  4 push/pull: (no tree) 4.366985e+00 (sec),  rate: 967.089 (1e6 edges/sec)
+speedup 3.84917
+nthreads  8 push/pull: (no tree) 2.415162e+00 (sec),  rate: 1748.65 (1e6 edges/sec)
+speedup 6.95989
+nthreads 16 push/pull: (no tree) 1.728917e+00 (sec),  rate: 2442.72 (1e6 edges/sec)
+speedup 9.72242
+nthreads 32 push/pull: (no tree) 1.415106e+00 (sec),  rate: 2984.42 (1e6 edges/sec)
+speedup 11.8784
+
+parallel (with tree):
+nthreads  1 push/pull (w/ tree): 1.979297e+01 (sec),  rate: 213.372 (1e6 edges/sec)
+nthreads  2 push/pull (w/ tree): 1.000421e+01 (sec),  rate: 422.149 (1e6 edges/sec)
+speedup 1.97846
+nthreads  4 push/pull (w/ tree): 5.293592e+00 (sec),  rate: 797.807 (1e6 edges/sec)
+speedup 3.73904
+nthreads  8 push/pull (w/ tree): 2.948612e+00 (sec),  rate: 1432.29 (1e6 edges/sec)
+speedup 6.71264
+nthreads 16 push/pull (w/ tree): 2.107479e+00 (sec),  rate: 2003.94 (1e6 edges/sec)
+speedup 9.39177
+nthreads 32 push/pull (w/ tree): 1.743436e+00 (sec),  rate: 2422.38 (1e6 edges/sec)
+speedup 11.3528
+
+v starts sparse: (nthread 40)
+pushpull sparse 3.122808e-04 (sec), rate: 1.35239e+07 (1e6 edges/sec)
+number of levels: 1 (for s = 0, single-source)
+# nodes visited (for single-source): 1 out of 134217726 (7.45058e-07 % of the graph)
+bfs_test: all tests passed
+------------------------------------------------------------
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+nthreads for simple BFS: 40
+
+  61578415x61578415 GraphBLAS bool matrix, sparse by row:
+  A, 1468364884 entries
+
+    (12,13)   1
+    (12,14)   1
+    (12,15)   1
+    (12,16)   1
+    (12,17)   1
+    (12,18)   1
+    (12,20)   1
+    (12,21)   1
+    (12,22)   1
+    (12,23)   1
+    (12,24)   1
+    (12,31)   1
+    (12,38)   1
+    (12,41)   1
+    (12,47)   1
+    (12,52)   1
+    (12,53)   1
+    (12,56)   1
+    (12,57)   1
+    (12,58)   1
+    (12,59)   1
+    (12,60)   1
+    (12,61)   1
+    (12,62)   1
+    (12,64)   1
+    (12,67)   1
+    (12,69)   1
+    (12,70)   1
+    (12,76)   1
+    (12,87)   1
+    ...
+
+==========input graph: nodes: 61578415 edges: 1468364884 source node: 0
+ nthreads: 40
+simple    time: 5.293976e-01 (sec), rate: 2773.65 (1e6 edges/sec)
+transpose time: 20.4876
+
+nthreads  1 push/pull: (no tree) 7.358492e+00 (sec),  rate: 199.547 (1e6 edges/sec)
+nthreads  2 push/pull: (no tree) 3.766802e+00 (sec),  rate: 389.817 (1e6 edges/sec)
+speedup 1.95351
+nthreads  4 push/pull: (no tree) 2.000965e+00 (sec),  rate: 733.828 (1e6 edges/sec)
+speedup 3.67747
+nthreads  8 push/pull: (no tree) 1.111948e+00 (sec),  rate: 1320.53 (1e6 edges/sec)
+speedup 6.61766
+nthreads 16 push/pull: (no tree) 6.787159e-01 (sec),  rate: 2163.45 (1e6 edges/sec)
+speedup 10.8418
+nthreads 32 push/pull: (no tree) 5.418409e-01 (sec),  rate: 2709.96 (1e6 edges/sec)
+speedup 13.5805
+
+parallel (with tree):
+nthreads  1 push/pull (w/ tree): 8.694551e+00 (sec),  rate: 168.883 (1e6 edges/sec)
+nthreads  2 push/pull (w/ tree): 4.548592e+00 (sec),  rate: 322.817 (1e6 edges/sec)
+speedup 1.91148
+nthreads  4 push/pull (w/ tree): 2.434743e+00 (sec),  rate: 603.088 (1e6 edges/sec)
+speedup 3.57103
+nthreads  8 push/pull (w/ tree): 1.376903e+00 (sec),  rate: 1066.43 (1e6 edges/sec)
+speedup 6.31457
+nthreads 16 push/pull (w/ tree): 8.587766e-01 (sec),  rate: 1709.83 (1e6 edges/sec)
+speedup 10.1243
+nthreads 32 push/pull (w/ tree): 7.070534e-01 (sec),  rate: 2076.74 (1e6 edges/sec)
+speedup 12.2969
+
+v starts sparse: (nthread 40)
+pushpull sparse 2.880674e-04 (sec), rate: 5.0973e+06 (1e6 edges/sec)
+number of levels: 1 (for s = 0, single-source)
+# nodes visited (for single-source): 1 out of 61578415 (1.62395e-06 % of the graph)
+bfs_test: all tests passed
+------------------------------------------------------------
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+nthreads for simple BFS: 40
+
+  134217728x134217728 GraphBLAS bool matrix, sparse by row:
+  A, 4294966740 entries
+
+    (0,8291853)   1
+    (0,9845139)   1
+    (0,14571172)   1
+    (0,16459757)   1
+    (0,27302127)   1
+    (0,27726180)   1
+    (0,30303523)   1
+    (0,32640525)   1
+    (0,33360373)   1
+    (0,40782998)   1
+    (0,41057943)   1
+    (0,43348321)   1
+    (0,50206206)   1
+    (0,52510658)   1
+    (0,53390371)   1
+    (0,53579654)   1
+    (0,54622695)   1
+    (0,57696071)   1
+    (0,59385788)   1
+    (0,60365539)   1
+    (0,64764501)   1
+    (0,64889445)   1
+    (0,72706136)   1
+    (0,77394182)   1
+    (0,82101150)   1
+    (0,86364056)   1
+    (0,86790574)   1
+    (0,90287459)   1
+    (0,104674459)   1
+    (0,109716228)   1
+    ...
+
+==========input graph: nodes: 134217728 edges: 4294966740 source node: 0
+ nthreads: 40
+simple    time: 8.144970e+01 (sec), rate: 52.7315 (1e6 edges/sec)
+transpose time: 78.2247
+
+nthreads  1 push/pull: (no tree) 1.270485e+02 (sec),  rate: 33.8057 (1e6 edges/sec)
+nthreads  2 push/pull: (no tree) 8.405850e+01 (sec),  rate: 51.095 (1e6 edges/sec)
+speedup 1.51143
+nthreads  4 push/pull: (no tree) 5.732329e+01 (sec),  rate: 74.9253 (1e6 edges/sec)
+speedup 2.21635
+nthreads  8 push/pull: (no tree) 4.073420e+01 (sec),  rate: 105.439 (1e6 edges/sec)
+speedup 3.11896
+nthreads 16 push/pull: (no tree) 3.239600e+01 (sec),  rate: 132.577 (1e6 edges/sec)
+speedup 3.92173
+nthreads 32 push/pull: (no tree) 3.113207e+01 (sec),  rate: 137.96 (1e6 edges/sec)
+speedup 4.08095
+
+parallel (with tree):
+nthreads  1 push/pull (w/ tree): 1.303436e+02 (sec),  rate: 32.9511 (1e6 edges/sec)
+nthreads  2 push/pull (w/ tree): 8.442520e+01 (sec),  rate: 50.873 (1e6 edges/sec)
+speedup 1.54389
+nthreads  4 push/pull (w/ tree): 5.926157e+01 (sec),  rate: 72.4747 (1e6 edges/sec)
+speedup 2.19946
+nthreads  8 push/pull (w/ tree): 4.409396e+01 (sec),  rate: 97.4049 (1e6 edges/sec)
+speedup 2.95604
+nthreads 16 push/pull (w/ tree): 3.578295e+01 (sec),  rate: 120.028 (1e6 edges/sec)
+speedup 3.64262
+nthreads 32 push/pull (w/ tree): 3.724249e+01 (sec),  rate: 115.324 (1e6 edges/sec)
+speedup 3.49986
+
+v starts sparse: (nthread 40)
+pushpull sparse 3.175494e+01 (sec), rate: 135.253 (1e6 edges/sec)
+number of levels: 8 (for s = 0, single-source)
+# nodes visited (for single-source): 134217728 out of 134217728 (100 % of the graph)
+bfs_test: all tests passed
+------------------------------------------------------------
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+nthreads for simple BFS: 40
+
+  23947347x23947347 GraphBLAS bool matrix, sparse by row:
+  A, 57708624 entries
+
+    (0,1)   1
+    (0,709)   1
+    (0,1049673)   1
+    (1,0)   1
+    (1,2097154)   1
+    (2,9)   1
+    (2,2097152)   1
+    (2,2097156)   1
+    (3,1903)   1
+    (3,1048578)   1
+    (4,5)   1
+    (4,2097153)   1
+    (5,4)   1
+    (5,11)   1
+    (5,1048579)   1
+    (6,7)   1
+    (6,1048580)   1
+    (6,1048582)   1
+    (7,6)   1
+    (8,33976)   1
+    (8,1048581)   1
+    (9,2)   1
+    ...
+
+==========input graph: nodes: 23947347 edges: 57708624 source node: 0
+ nthreads: 40
+simple    time: 1.300215e+01 (sec), rate: 4.43839 (1e6 edges/sec)
+transpose time: 0.702298
+
+nthreads  1 push/pull: (no tree) 1.838820e+01 (sec),  rate: 3.13835 (1e6 edges/sec)
+nthreads  2 push/pull: (no tree) 1.452665e+01 (sec),  rate: 3.9726 (1e6 edges/sec)
+speedup 1.26583
+nthreads  4 push/pull: (no tree) 1.327465e+01 (sec),  rate: 4.34728 (1e6 edges/sec)
+speedup 1.38521
+nthreads  8 push/pull: (no tree) 1.299685e+01 (sec),  rate: 4.4402 (1e6 edges/sec)
+speedup 1.41482
+nthreads 16 push/pull: (no tree) 1.291833e+01 (sec),  rate: 4.46719 (1e6 edges/sec)
+speedup 1.42342
+nthreads 32 push/pull: (no tree) 1.287571e+01 (sec),  rate: 4.48198 (1e6 edges/sec)
+speedup 1.42813
+
+parallel (with tree):
+nthreads  1 push/pull (w/ tree): 1.988076e+01 (sec),  rate: 2.90274 (1e6 edges/sec)
+nthreads  2 push/pull (w/ tree): 1.625262e+01 (sec),  rate: 3.55073 (1e6 edges/sec)
+speedup 1.22323
+nthreads  4 push/pull (w/ tree): 1.471130e+01 (sec),  rate: 3.92274 (1e6 edges/sec)
+speedup 1.35139
+nthreads  8 push/pull (w/ tree): 1.438698e+01 (sec),  rate: 4.01117 (1e6 edges/sec)
+speedup 1.38186
+nthreads 16 push/pull (w/ tree): 1.412046e+01 (sec),  rate: 4.08688 (1e6 edges/sec)
+speedup 1.40794
+nthreads 32 push/pull (w/ tree): 1.421792e+01 (sec),  rate: 4.05887 (1e6 edges/sec)
+speedup 1.39829
+
+v starts sparse: (nthread 40)
+pushpull sparse 1.296961e+01 (sec), rate: 4.44953 (1e6 edges/sec)
+number of levels: 6262 (for s = 0, single-source)
+# nodes visited (for single-source): 23947347 out of 23947347 (100 % of the graph)
+bfs_test: all tests passed
+------------------------------------------------------------
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+nthreads for simple BFS: 40

--- a/Test/BFS/bfs_test.c
+++ b/Test/BFS/bfs_test.c
@@ -81,7 +81,65 @@ int main (int argc, char **argv)
     //--------------------------------------------------------------------------
 
     // read in the file in Matrix Market format
-    LAGRAPH_OK (LAGraph_mmread (&A, stdin)) ;
+    //LAGRAPH_OK (LAGraph_mmread (&A, stdin)) ;
+
+    if (argc > 1)
+    {
+        // Usage:
+        //      ./bfs_test matrixfile.mtx
+        //      ./bfs_test matrixfile.grb
+
+        // read in the file in Matrix Market format from the input file
+        char *filename = argv [1] ;
+        printf ("matrix: %s\n", filename) ;
+
+        // find the filename extension
+        size_t len = strlen (filename) ;
+        char *ext = NULL ;
+        for (int k = len-1 ; k >= 0 ; k--)
+        {
+            if (filename [k] == '.')
+            {
+                ext = filename + k ;
+                printf ("[%s]\n", ext) ;
+                break ;
+            }
+        }
+        bool is_binary = (ext != NULL && strncmp (ext, ".grb", 4) == 0) ;
+
+        if (is_binary)
+        {
+            printf ("Reading binary file: %s\n", filename) ;
+            LAGRAPH_OK (LAGraph_binread (&A, filename)) ;
+        }
+        else
+        {
+            printf ("Reading Matrix Market file: %s\n", filename) ;
+            FILE *f = fopen (filename, "r") ;
+            if (f == NULL)
+            {
+                printf ("Matrix file not found: [%s]\n", filename) ;
+                exit (1) ;
+            }
+            LAGRAPH_OK (LAGraph_mmread(&A, f));
+            fclose (f) ;
+        }
+
+    }
+    else
+    {
+
+        // Usage:  ./bfs_test < matrixfile.mtx
+        printf ("matrix: from stdin\n") ;
+
+        // read in the file in Matrix Market format from stdin
+        LAGRAPH_OK (LAGraph_mmread(&A, stdin));
+    }
+
+////////////////////////
+
+
+
     // GxB_fprint (A, GxB_COMPLETE, stderr) ;
     // LAGraph_mmwrite (A, stderr) ;
 

--- a/Test/BFS/do_gap
+++ b/Test/BFS/do_gap
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./build/bfs_test ~/GAP/GAP-web/GAP-web.grb ~/GAP/GAP-web/GAP-web_sources.mtx
+./build/bfs_test ~/GAP/GAP-kron/GAP-kron.grb ~/GAP/GAP-kron/GAP-kron_sources.mtx
+./build/bfs_test ~/GAP/GAP-twitter/GAP-twitter.grb ~/GAP/GAP-twitter/GAP-twitter_sources.mtx
+./build/bfs_test ~/GAP/GAP-urand/GAP-urand.grb ~/GAP/GAP-urand/GAP-urand_sources.mtx
+./build/bfs_test ~/GAP/GAP-road/GAP-road.grb ~/GAP/GAP-road/GAP-road_sources.mtx
+

--- a/Test/BetweennessCentrality/2ndJan.out
+++ b/Test/BetweennessCentrality/2ndJan.out
@@ -1,0 +1,1593 @@
+matrix: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+sources: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web_sources.mtx
+read time: 15.4614 sec
+
+  50636151x50636151 GraphBLAS bool matrix, sparse by row:
+  A, 1930292948 entries
+
+    (10,49817219)   1
+    (10,49824797)   1
+    (10,49824842)   1
+    (10,49824843)   1
+    (10,49824846)   1
+    (10,49826026)   1
+    (10,49826027)   1
+    (10,49826709)   1
+    (10,49826710)   1
+    (10,49826711)   1
+    (10,49826712)   1
+    (10,49826713)   1
+    (10,49826714)   1
+    (10,49826715)   1
+    (10,49826716)   1
+    (10,49826717)   1
+    (10,49826719)   1
+    (10,49827761)   1
+    (10,49853332)   1
+    (10,49853570)   1
+    (10,49853571)   1
+    (10,49853572)   1
+    (10,49853573)   1
+    (10,49853574)   1
+    (10,49853575)   1
+    (10,49855627)   1
+    (10,50184826)   1
+    (10,50284715)   1
+    (10,50284718)   1
+    (10,50284719)   1
+    ...
+
+  64x1 GraphBLAS double matrix, sparse by row:
+  SourceNodes, 64 entries
+
+    (0,0)    10219453
+    (1,0)    44758212
+    (2,0)    890672
+    (3,0)    13843757
+    (4,0)    14168063
+    (5,0)    20906931
+    (6,0)    12189585
+    (7,0)    26352336
+    (8,0)    43500687
+    (9,0)    8987025
+    (10,0)    5699763
+    (11,0)    41436456
+    (12,0)    5030728
+    (13,0)    40735219
+    (14,0)    16533564
+    (15,0)    28700167
+    (16,0)    64712
+    (17,0)    39634751
+    (18,0)    16037780
+    (19,0)    27152740
+    (20,0)    16404062
+    (21,0)    20491964
+    (22,0)    5322424
+    (23,0)    21420954
+    (24,0)    26622110
+    (25,0)    5882876
+    (26,0)    18091041
+    (27,0)    10665897
+    (28,0)    18634423
+    (29,0)    18138716
+    (30,0)    2355536
+    (31,0)    32885206
+    (32,0)    40657441
+    (33,0)    35196168
+    (34,0)    45544427
+    (35,0)    6175520
+    (36,0)    40058319
+    (37,0)    50626231
+    (38,0)    36571020
+    (39,0)    49397053
+    (40,0)    23434266
+    (41,0)    2299445
+    (42,0)    32873824
+    (43,0)    25978283
+    (44,0)    2461716
+    (45,0)    22787315
+    (46,0)    30759948
+    (47,0)    7428895
+    (48,0)    39173871
+    (49,0)    43194210
+    (50,0)    26361510
+    (51,0)    39747212
+    (52,0)    30670030
+    (53,0)    41483034
+    (54,0)    9358667
+    (55,0)    9945009
+    (56,0)    3355245
+    (57,0)    33831270
+    (58,0)    45124745
+    (59,0)    16137878
+    (60,0)    11235449
+    (61,0)    37509145
+    (62,0)    27402415
+    (63,0)    39546084
+
+setup time: 10.2872 sec
+A is unsymmetric
+
+  50636151x50636151 GraphBLAS bool matrix, sparse by row:
+  AT, 1930292948 entries
+
+    (0,50395004)   1
+    (1,50395004)   1
+    (2,50395004)   1
+    (3,50395004)   1
+    (4,50395004)   1
+    (5,50395004)   1
+    (6,50395004)   1
+    (7,50395004)   1
+    (8,50395004)   1
+    (9,50395004)   1
+    ...
+transpose time: 14.3601
+
+========== input graph: nodes: 50636151 edges: 1930292948
+TESTING LAGraphX_bc_batch3 (saxpy in both phases, nthreads 40
+
+Trial 1 : sources: [ 10219452 44758211 890671 13843756 ]
+starting 1st phase
+Xbc setup 0.44795 sec
+Xbc bfs phase: 29.9025
+    bfs mxm:   29.3509
+    bfs other  0.551648
+Xbc: setup for backtrack     0.173655
+starting 2nd phase
+Xbx 2nd phase: 9.82227
+    2nd mxm  : 9.12619
+    2nd other: 0.696085
+Xbc wrapup:    0.28609
+Xbc total:     40.6325
+Batch    time: 4.063283e+01 (sec), rate: 47.5057 (1e6 edges/sec)
+
+Trial 2 : sources: [ 14168062 20906930 12189584 26352335 ]
+starting 1st phase
+Xbc setup 0.443943 sec
+Xbc bfs phase: 26.5779
+    bfs mxm:   26.0281
+    bfs other  0.549714
+Xbc: setup for backtrack     0.160632
+starting 2nd phase
+Xbx 2nd phase: 8.95728
+    2nd mxm  : 8.13069
+    2nd other: 0.826586
+Xbc wrapup:    0.272324
+Xbc total:     36.412
+Batch    time: 3.641214e+01 (sec), rate: 53.0123 (1e6 edges/sec)
+
+Trial 3 : sources: [ 43500686 8987024 5699762 41436455 ]
+starting 1st phase
+Xbc setup 0.418878 sec
+Xbc bfs phase: 26.6171
+    bfs mxm:   26.1155
+    bfs other  0.501579
+Xbc: setup for backtrack     0.169865
+starting 2nd phase
+Xbx 2nd phase: 8.8119
+    2nd mxm  : 8.02424
+    2nd other: 0.787651
+Xbc wrapup:    0.272084
+Xbc total:     36.2898
+Batch    time: 3.628994e+01 (sec), rate: 53.1908 (1e6 edges/sec)
+
+Trial 4 : sources: [ 5030727 40735218 16533563 28700166 ]
+starting 1st phase
+Xbc setup 0.424475 sec
+Xbc bfs phase: 40.0049
+    bfs mxm:   39.3737
+    bfs other  0.631203
+Xbc: setup for backtrack     0.154452
+starting 2nd phase
+Xbx 2nd phase: 11.4034
+    2nd mxm  : 10.3435
+    2nd other: 1.05993
+Xbc wrapup:    0.286804
+Xbc total:     52.2741
+Batch    time: 5.227420e+01 (sec), rate: 36.9263 (1e6 edges/sec)
+
+Trial 5 : sources: [ 64711 39634750 16037779 27152739 ]
+starting 1st phase
+Xbc setup 0.428312 sec
+Xbc bfs phase: 32.2704
+    bfs mxm:   31.7095
+    bfs other  0.560855
+Xbc: setup for backtrack     0.157191
+starting 2nd phase
+Xbx 2nd phase: 11.2058
+    2nd mxm  : 10.3597
+    2nd other: 0.846117
+Xbc wrapup:    0.287031
+Xbc total:     44.3488
+Batch    time: 4.434885e+01 (sec), rate: 43.5252 (1e6 edges/sec)
+
+Trial 6 : sources: [ 16404061 20491963 5322423 21420953 ]
+starting 1st phase
+Xbc setup 0.424627 sec
+Xbc bfs phase: 34.8454
+    bfs mxm:   34.2141
+    bfs other  0.63138
+Xbc: setup for backtrack     0.169162
+starting 2nd phase
+Xbx 2nd phase: 11.972
+    2nd mxm  : 10.9741
+    2nd other: 0.997927
+Xbc wrapup:    0.287178
+Xbc total:     47.6984
+Batch    time: 4.769855e+01 (sec), rate: 40.4686 (1e6 edges/sec)
+
+Trial 7 : sources: [ 26622109 5882875 18091040 10665896 ]
+starting 1st phase
+Xbc setup 0.428221 sec
+Xbc bfs phase: 27.6531
+    bfs mxm:   27.1234
+    bfs other  0.529722
+Xbc: setup for backtrack     0.170565
+starting 2nd phase
+Xbx 2nd phase: 9.45599
+    2nd mxm  : 8.65158
+    2nd other: 0.804404
+Xbc wrapup:    0.275332
+Xbc total:     37.9832
+Batch    time: 3.798330e+01 (sec), rate: 50.8195 (1e6 edges/sec)
+
+Trial 8 : sources: [ 18634422 18138715 2355535 32885205 ]
+starting 1st phase
+Xbc setup 0.428571 sec
+Xbc bfs phase: 24.1169
+    bfs mxm:   23.6555
+    bfs other  0.461424
+Xbc: setup for backtrack     0.158762
+starting 2nd phase
+Xbx 2nd phase: 8.31625
+    2nd mxm  : 7.59902
+    2nd other: 0.717229
+Xbc wrapup:    0.295189
+Xbc total:     33.3157
+Batch    time: 3.331576e+01 (sec), rate: 57.9393 (1e6 edges/sec)
+
+Trial 9 : sources: [ 40657440 35196167 45544426 6175519 ]
+starting 1st phase
+Xbc setup 0.432448 sec
+Xbc bfs phase: 24.8852
+    bfs mxm:   24.421
+    bfs other  0.464223
+Xbc: setup for backtrack      0.15642
+starting 2nd phase
+Xbx 2nd phase: 8.19529
+    2nd mxm  : 7.49213
+    2nd other: 0.703162
+Xbc wrapup:    0.275
+Xbc total:     33.9444
+Batch    time: 3.394447e+01 (sec), rate: 56.8662 (1e6 edges/sec)
+
+Trial 10 : sources: [ 40058318 50626230 36571019 49397052 ]
+starting 1st phase
+Xbc setup 0.426369 sec
+Xbc bfs phase: 31.0784
+    bfs mxm:   30.545
+    bfs other  0.533357
+Xbc: setup for backtrack      0.15605
+starting 2nd phase
+Xbx 2nd phase: 10.3785
+    2nd mxm  : 9.54807
+    2nd other: 0.830385
+Xbc wrapup:    0.291739
+Xbc total:     42.331
+Batch    time: 4.233111e+01 (sec), rate: 45.5999 (1e6 edges/sec)
+
+Trial 11 : sources: [ 23434265 2299444 32873823 25978282 ]
+starting 1st phase
+Xbc setup 0.431658 sec
+Xbc bfs phase: 23.4225
+    bfs mxm:   22.9798
+    bfs other  0.442697
+Xbc: setup for backtrack     0.174182
+starting 2nd phase
+Xbx 2nd phase: 7.9289
+    2nd mxm  : 7.28176
+    2nd other: 0.647135
+Xbc wrapup:    0.273486
+Xbc total:     32.2307
+Batch    time: 3.223081e+01 (sec), rate: 59.8897 (1e6 edges/sec)
+
+Trial 12 : sources: [ 2461715 22787314 30759947 7428894 ]
+starting 1st phase
+Xbc setup 0.428085 sec
+Xbc bfs phase: 22.2852
+    bfs mxm:   21.8727
+    bfs other  0.412504
+Xbc: setup for backtrack     0.158586
+starting 2nd phase
+Xbx 2nd phase: 6.44639
+    2nd mxm  : 5.80285
+    2nd other: 0.643539
+Xbc wrapup:    0.263433
+Xbc total:     29.5817
+Batch    time: 2.958178e+01 (sec), rate: 65.2528 (1e6 edges/sec)
+
+Trial 13 : sources: [ 39173870 43194209 26361509 39747211 ]
+starting 1st phase
+Xbc setup 0.429364 sec
+Xbc bfs phase: 0.0547372
+    bfs mxm:   0.0363252
+    bfs other  0.018412
+Xbc: setup for backtrack      0.15865
+starting 2nd phase
+Xbx 2nd phase: 0.0202357
+    2nd mxm  : 0.0198375
+    2nd other: 0.000398207
+Xbc wrapup:    0.236367
+Xbc total:     0.899354
+Batch    time: 8.994204e-01 (sec), rate: 2146.15 (1e6 edges/sec)
+
+Trial 14 : sources: [ 30670029 41483033 9358666 9945008 ]
+starting 1st phase
+Xbc setup 0.429294 sec
+Xbc bfs phase: 32.1277
+    bfs mxm:   31.5889
+    bfs other  0.538762
+Xbc: setup for backtrack      0.17059
+starting 2nd phase
+Xbx 2nd phase: 10.2049
+    2nd mxm  : 9.31533
+    2nd other: 0.889525
+Xbc wrapup:    0.289419
+Xbc total:     43.2218
+Batch    time: 4.322192e+01 (sec), rate: 44.66 (1e6 edges/sec)
+
+Trial 15 : sources: [ 3355244 33831269 45124744 16137877 ]
+starting 1st phase
+Xbc setup 0.428021 sec
+Xbc bfs phase: 25.8165
+    bfs mxm:   25.3315
+    bfs other  0.484988
+Xbc: setup for backtrack     0.176853
+starting 2nd phase
+Xbx 2nd phase: 8.74964
+    2nd mxm  : 8.04694
+    2nd other: 0.702702
+Xbc wrapup:    0.273124
+Xbc total:     35.4442
+Batch    time: 3.544426e+01 (sec), rate: 54.46 (1e6 edges/sec)
+
+Trial 16 : sources: [ 11235448 37509144 27402414 39546083 ]
+starting 1st phase
+Xbc setup 0.431749 sec
+Xbc bfs phase: 31.0087
+    bfs mxm:   30.4787
+    bfs other  0.530001
+Xbc: setup for backtrack     0.160682
+starting 2nd phase
+Xbx 2nd phase: 9.92446
+    2nd mxm  : 9.02661
+    2nd other: 0.897847
+Xbc wrapup:    0.291644
+Xbc total:     41.8173
+Batch    time: 4.181736e+01 (sec), rate: 46.1601 (1e6 edges/sec)
+ntrials: 16
+Average time per trial (batch):   36.7767 sec
+build/bc_gap_test: all tests passed
+matrix: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+sources: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron_sources.mtx
+read time: 40.8933 sec
+
+  134217726x134217726 GraphBLAS bool matrix, sparse by row:
+  A, 4223264644 entries
+
+    (1,83111928)   1
+    (2,113772338)   1
+    (9,26920261)   1
+    (9,33335674)   1
+    (9,90905511)   1
+    (9,92964069)   1
+    (9,126874301)   1
+    (11,3075467)   1
+    (11,11283179)   1
+    (11,14136330)   1
+    (11,18241662)   1
+    (11,21256905)   1
+    (11,26197037)   1
+    (11,34992956)   1
+    (11,49762924)   1
+    (11,54231301)   1
+    (11,55275316)   1
+    (11,55896288)   1
+    (11,56613538)   1
+    (11,69378808)   1
+    (11,76391974)   1
+    (11,77970070)   1
+    (11,80121717)   1
+    (11,113872174)   1
+    (11,115829864)   1
+    (11,125066355)   1
+    (11,129708509)   1
+    (11,131285585)   1
+    (11,132549336)   1
+    (14,11049596)   1
+    ...
+
+  64x1 GraphBLAS double matrix, sparse by row:
+  SourceNodes, 64 entries
+
+    (0,0)    2338013
+    (1,0)    31997660
+    (2,0)    23590941
+    (3,0)    43400605
+    (4,0)    75337938
+    (5,0)    169868
+    (6,0)    104041221
+    (7,0)    94177943
+    (8,0)    32871358
+    (9,0)    56230003
+    (10,0)    69883038
+    (11,0)    9346346
+    (12,0)    48915359
+    (13,0)    122571174
+    (14,0)    6183280
+    (15,0)    86323664
+    (16,0)    106725781
+    (17,0)    92389939
+    (18,0)    16210739
+    (19,0)    59816701
+    (20,0)    111669930
+    (21,0)    102831412
+    (22,0)    113384801
+    (23,0)    43872565
+    (24,0)    80508828
+    (25,0)    26105649
+    (26,0)    8807517
+    (27,0)    118452456
+    (28,0)    121818860
+    (29,0)    42361929
+    (30,0)    29493054
+    (31,0)    98461504
+    (32,0)    71931338
+    (33,0)    103808469
+    (34,0)    4092346
+    (35,0)    115276242
+    (36,0)    4649344
+    (37,0)    76656190
+    (38,0)    31312002
+    (39,0)    111334128
+    (40,0)    100962919
+    (41,0)    41823216
+    (42,0)    22631241
+    (43,0)    42848462
+    (44,0)    79485149
+    (45,0)    106818743
+    (46,0)    73347975
+    (47,0)    78848446
+    (48,0)    109920511
+    (49,0)    121492134
+    (50,0)    101037297
+    (51,0)    15438601
+    (52,0)    4584785
+    (53,0)    124503846
+    (54,0)    87241744
+    (55,0)    108297009
+    (56,0)    33955083
+    (57,0)    79934824
+    (58,0)    8608482
+    (59,0)    82435064
+    (60,0)    46579272
+    (61,0)    515422
+    (62,0)    121530468
+    (63,0)    127978737
+
+setup time: 22.4912 sec
+A is symmetric
+transpose time: 74.7329
+
+========== input graph: nodes: 134217726 edges: 4223264644
+TESTING LAGraphX_bc_batch3 (saxpy in both phases, nthreads 40
+
+Trial 1 : sources: [ 2338012 31997659 23590940 43400604 ]
+starting 1st phase
+Xbc setup 1.12846 sec
+Xbc bfs phase: 196.067
+    bfs mxm:   195.459
+    bfs other  0.607456
+Xbc: setup for backtrack      0.39952
+starting 2nd phase
+Xbx 2nd phase: 87.2946
+    2nd mxm  : 86.0222
+    2nd other: 1.27244
+Xbc wrapup:    0.734484
+Xbc total:     285.624
+Batch    time: 2.856241e+02 (sec), rate: 14.7861 (1e6 edges/sec)
+
+Trial 2 : sources: [ 75337937 169867 104041220 94177942 ]
+starting 1st phase
+Xbc setup 1.13342 sec
+Xbc bfs phase: 147.992
+    bfs mxm:   147.409
+    bfs other  0.582521
+Xbc: setup for backtrack     0.409757
+starting 2nd phase
+Xbx 2nd phase: 50.1374
+    2nd mxm  : 48.9001
+    2nd other: 1.23728
+Xbc wrapup:    0.749863
+Xbc total:     200.422
+Batch    time: 2.004224e+02 (sec), rate: 21.0718 (1e6 edges/sec)
+
+Trial 3 : sources: [ 32871357 56230002 69883037 9346345 ]
+starting 1st phase
+Xbc setup 1.1164 sec
+Xbc bfs phase: 214.348
+    bfs mxm:   213.72
+    bfs other  0.627128
+Xbc: setup for backtrack     0.410327
+starting 2nd phase
+Xbx 2nd phase: 52.7731
+    2nd mxm  : 51.4098
+    2nd other: 1.36331
+Xbc wrapup:    0.72891
+Xbc total:     269.376
+Batch    time: 2.693764e+02 (sec), rate: 15.6779 (1e6 edges/sec)
+
+Trial 4 : sources: [ 48915358 122571173 6183279 86323663 ]
+starting 1st phase
+Xbc setup 1.10606 sec
+Xbc bfs phase: 193.925
+    bfs mxm:   193.3
+    bfs other  0.625559
+Xbc: setup for backtrack     0.414679
+starting 2nd phase
+Xbx 2nd phase: 47.3451
+    2nd mxm  : 46.0038
+    2nd other: 1.34131
+Xbc wrapup:    0.741366
+Xbc total:     243.532
+Batch    time: 2.435325e+02 (sec), rate: 17.3417 (1e6 edges/sec)
+
+Trial 5 : sources: [ 106725780 92389938 16210738 59816700 ]
+starting 1st phase
+Xbc setup 1.11946 sec
+Xbc bfs phase: 155.143
+    bfs mxm:   154.578
+    bfs other  0.56435
+Xbc: setup for backtrack      0.40836
+starting 2nd phase
+Xbx 2nd phase: 48.6135
+    2nd mxm  : 47.4642
+    2nd other: 1.14931
+Xbc wrapup:    0.743284
+Xbc total:     206.027
+Batch    time: 2.060274e+02 (sec), rate: 20.4986 (1e6 edges/sec)
+
+Trial 6 : sources: [ 111669929 102831411 113384800 43872564 ]
+starting 1st phase
+Xbc setup 1.1151 sec
+Xbc bfs phase: 200.578
+    bfs mxm:   199.969
+    bfs other  0.608587
+Xbc: setup for backtrack     0.413605
+starting 2nd phase
+Xbx 2nd phase: 81.8425
+    2nd mxm  : 80.5229
+    2nd other: 1.31966
+Xbc wrapup:    0.73135
+Xbc total:     284.68
+Batch    time: 2.846803e+02 (sec), rate: 14.8351 (1e6 edges/sec)
+
+Trial 7 : sources: [ 80508827 26105648 8807516 118452455 ]
+starting 1st phase
+Xbc setup 1.11022 sec
+Xbc bfs phase: 227.195
+    bfs mxm:   226.592
+    bfs other  0.603372
+Xbc: setup for backtrack      0.41352
+starting 2nd phase
+Xbx 2nd phase: 76.6553
+    2nd mxm  : 75.3491
+    2nd other: 1.3062
+Xbc wrapup:    0.727225
+Xbc total:     306.101
+Batch    time: 3.061015e+02 (sec), rate: 13.7969 (1e6 edges/sec)
+
+Trial 8 : sources: [ 121818859 42361928 29493053 98461503 ]
+starting 1st phase
+Xbc setup 1.11057 sec
+Xbc bfs phase: 144.404
+    bfs mxm:   143.82
+    bfs other  0.584302
+Xbc: setup for backtrack     0.409974
+starting 2nd phase
+Xbx 2nd phase: 50.6154
+    2nd mxm  : 49.5641
+    2nd other: 1.05131
+Xbc wrapup:    0.734007
+Xbc total:     197.274
+Batch    time: 1.972740e+02 (sec), rate: 21.4081 (1e6 edges/sec)
+
+Trial 9 : sources: [ 71931337 103808468 4092345 115276241 ]
+starting 1st phase
+Xbc setup 1.11497 sec
+Xbc bfs phase: 220.229
+    bfs mxm:   219.638
+    bfs other  0.591076
+Xbc: setup for backtrack     0.413397
+starting 2nd phase
+Xbx 2nd phase: 62.6539
+    2nd mxm  : 61.4284
+    2nd other: 1.22547
+Xbc wrapup:    0.749376
+Xbc total:     285.16
+Batch    time: 2.851603e+02 (sec), rate: 14.8101 (1e6 edges/sec)
+
+Trial 10 : sources: [ 4649343 76656189 31312001 111334127 ]
+starting 1st phase
+Xbc setup 1.11189 sec
+Xbc bfs phase: 159.1
+    bfs mxm:   158.5
+    bfs other  0.599594
+Xbc: setup for backtrack     0.409557
+starting 2nd phase
+Xbx 2nd phase: 50.2891
+    2nd mxm  : 48.9512
+    2nd other: 1.33787
+Xbc wrapup:    0.74016
+Xbc total:     211.65
+Batch    time: 2.116503e+02 (sec), rate: 19.954 (1e6 edges/sec)
+
+Trial 11 : sources: [ 100962918 41823215 22631240 42848461 ]
+starting 1st phase
+Xbc setup 1.11339 sec
+Xbc bfs phase: 170.782
+    bfs mxm:   170.066
+    bfs other  0.715913
+Xbc: setup for backtrack     0.408008
+starting 2nd phase
+Xbx 2nd phase: 50.7792
+    2nd mxm  : 49.1391
+    2nd other: 1.64006
+Xbc wrapup:    0.745406
+Xbc total:     223.828
+Batch    time: 2.238280e+02 (sec), rate: 18.8683 (1e6 edges/sec)
+
+Trial 12 : sources: [ 79485148 106818742 73347974 78848445 ]
+starting 1st phase
+Xbc setup 1.11574 sec
+Xbc bfs phase: 144.314
+    bfs mxm:   143.747
+    bfs other  0.567147
+Xbc: setup for backtrack     0.411008
+starting 2nd phase
+Xbx 2nd phase: 49.2145
+    2nd mxm  : 48.1117
+    2nd other: 1.10282
+Xbc wrapup:    0.733339
+Xbc total:     195.789
+Batch    time: 1.957887e+02 (sec), rate: 21.5705 (1e6 edges/sec)
+
+Trial 13 : sources: [ 109920510 121492133 101037296 15438600 ]
+starting 1st phase
+Xbc setup 1.11461 sec
+Xbc bfs phase: 170.821
+    bfs mxm:   170.178
+    bfs other  0.642572
+Xbc: setup for backtrack      0.41359
+starting 2nd phase
+Xbx 2nd phase: 65.2304
+    2nd mxm  : 63.8143
+    2nd other: 1.41607
+Xbc wrapup:    0.734028
+Xbc total:     238.313
+Batch    time: 2.383135e+02 (sec), rate: 17.7215 (1e6 edges/sec)
+
+Trial 14 : sources: [ 4584784 124503845 87241743 108297008 ]
+starting 1st phase
+Xbc setup 1.1084 sec
+Xbc bfs phase: 204.054
+    bfs mxm:   203.292
+    bfs other  0.761548
+Xbc: setup for backtrack     0.409553
+starting 2nd phase
+Xbx 2nd phase: 53.1868
+    2nd mxm  : 51.4908
+    2nd other: 1.69602
+Xbc wrapup:    0.747515
+Xbc total:     259.506
+Batch    time: 2.595063e+02 (sec), rate: 16.2742 (1e6 edges/sec)
+
+Trial 15 : sources: [ 33955082 79934823 8608481 82435063 ]
+starting 1st phase
+Xbc setup 1.11522 sec
+Xbc bfs phase: 228.298
+    bfs mxm:   227.678
+    bfs other  0.619878
+Xbc: setup for backtrack     0.415828
+starting 2nd phase
+Xbx 2nd phase: 80.0603
+    2nd mxm  : 78.7015
+    2nd other: 1.35885
+Xbc wrapup:    0.736989
+Xbc total:     310.626
+Batch    time: 3.106262e+02 (sec), rate: 13.596 (1e6 edges/sec)
+
+Trial 16 : sources: [ 46579271 515421 121530467 127978736 ]
+starting 1st phase
+Xbc setup 1.11307 sec
+Xbc bfs phase: 151.535
+    bfs mxm:   150.918
+    bfs other  0.616939
+Xbc: setup for backtrack     0.412518
+starting 2nd phase
+Xbx 2nd phase: 50.6714
+    2nd mxm  : 49.4126
+    2nd other: 1.2588
+Xbc wrapup:    0.758714
+Xbc total:     204.491
+Batch    time: 2.044911e+02 (sec), rate: 20.6526 (1e6 edges/sec)
+ntrials: 16
+Average time per trial (batch):   245.15 sec
+build/bc_gap_test: all tests passed
+matrix: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+sources: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter_sources.mtx
+read time: 15.9544 sec
+
+  61578415x61578415 GraphBLAS bool matrix, sparse by row:
+  A, 1468364884 entries
+
+    (12,13)   1
+    (12,14)   1
+    (12,15)   1
+    (12,16)   1
+    (12,17)   1
+    (12,18)   1
+    (12,20)   1
+    (12,21)   1
+    (12,22)   1
+    (12,23)   1
+    (12,24)   1
+    (12,31)   1
+    (12,38)   1
+    (12,41)   1
+    (12,47)   1
+    (12,52)   1
+    (12,53)   1
+    (12,56)   1
+    (12,57)   1
+    (12,58)   1
+    (12,59)   1
+    (12,60)   1
+    (12,61)   1
+    (12,62)   1
+    (12,64)   1
+    (12,67)   1
+    (12,69)   1
+    (12,70)   1
+    (12,76)   1
+    (12,87)   1
+    ...
+
+  64x1 GraphBLAS double matrix, sparse by row:
+  SourceNodes, 64 entries
+
+    (0,0)    12441073
+    (1,0)    54488258
+    (2,0)    25451916
+    (3,0)    57714474
+    (4,0)    14839495
+    (5,0)    32081105
+    (6,0)    52957358
+    (7,0)    50444381
+    (8,0)    49590702
+    (9,0)    20127817
+    (10,0)    34939334
+    (11,0)    48251002
+    (12,0)    19524254
+    (13,0)    43676727
+    (14,0)    33055509
+    (15,0)    15244688
+    (16,0)    24946739
+    (17,0)    6479473
+    (18,0)    26077683
+    (19,0)    22023876
+    (20,0)    22081916
+    (21,0)    40034163
+    (22,0)    49496015
+    (23,0)    42847508
+    (24,0)    52409558
+    (25,0)    55445389
+    (26,0)    22028098
+    (27,0)    48766649
+    (28,0)    44521242
+    (29,0)    60135543
+    (30,0)    28528672
+    (31,0)    9678013
+    (32,0)    40020307
+    (33,0)    31625736
+    (34,0)    37446893
+    (35,0)    51788953
+    (36,0)    52584256
+    (37,0)    20346697
+    (38,0)    48387910
+    (39,0)    37337428
+    (40,0)    50501085
+    (41,0)    30130062
+    (42,0)    41185894
+    (43,0)    56495704
+    (44,0)    45663306
+    (45,0)    33359461
+    (46,0)    48143059
+    (47,0)    33291514
+    (48,0)    53461446
+    (49,0)    29340611
+    (50,0)    34148499
+    (51,0)    49171807
+    (52,0)    35550697
+    (53,0)    14521508
+    (54,0)    51633219
+    (55,0)    46823383
+    (56,0)    19396274
+    (57,0)    19871751
+    (58,0)    36862678
+    (59,0)    49539127
+    (60,0)    34016453
+    (61,0)    36567396
+    (62,0)    55487794
+    (63,0)    14391371
+
+setup time: 8.1404 sec
+A is unsymmetric
+
+  61578415x61578415 GraphBLAS bool matrix, sparse by row:
+  AT, 1468364884 entries
+
+    (12,13)   1
+    (12,14)   1
+    (12,15)   1
+    (12,16)   1
+    (12,17)   1
+    (12,18)   1
+    (12,20)   1
+    (12,21)   1
+    (12,22)   1
+    (12,23)   1
+    (12,24)   1
+    (12,31)   1
+    (12,38)   1
+    (12,41)   1
+    (12,53)   1
+    (12,56)   1
+    (12,57)   1
+    (12,58)   1
+    (12,59)   1
+    (12,60)   1
+    (12,61)   1
+    (12,62)   1
+    (12,64)   1
+    (12,67)   1
+    (12,70)   1
+    (12,76)   1
+    (12,87)   1
+    (12,92)   1
+    (12,94)   1
+    (12,104)   1
+    ...
+transpose time: 27.9106
+
+========== input graph: nodes: 61578415 edges: 1468364884
+TESTING LAGraphX_bc_batch3 (saxpy in both phases, nthreads 40
+
+Trial 1 : sources: [ 12441072 54488257 25451915 57714473 ]
+starting 1st phase
+Xbc setup 0.535326 sec
+Xbc bfs phase: 83.4366
+    bfs mxm:   83.0612
+    bfs other  0.375408
+Xbc: setup for backtrack     0.201439
+starting 2nd phase
+Xbx 2nd phase: 41.6301
+    2nd mxm  : 40.8778
+    2nd other: 0.752283
+Xbc wrapup:    0.353336
+Xbc total:     126.157
+Batch    time: 1.261569e+02 (sec), rate: 11.6392 (1e6 edges/sec)
+
+Trial 2 : sources: [ 14839494 32081104 52957357 50444380 ]
+starting 1st phase
+Xbc setup 0.540429 sec
+Xbc bfs phase: 76.9506
+    bfs mxm:   76.5598
+    bfs other  0.390767
+Xbc: setup for backtrack     0.208968
+starting 2nd phase
+Xbx 2nd phase: 19.9753
+    2nd mxm  : 19.1025
+    2nd other: 0.872757
+Xbc wrapup:    0.358535
+Xbc total:     98.0338
+Batch    time: 9.803382e+01 (sec), rate: 14.9781 (1e6 edges/sec)
+
+Trial 3 : sources: [ 49590701 20127816 34939333 48251001 ]
+starting 1st phase
+Xbc setup 0.538278 sec
+Xbc bfs phase: 77.9505
+    bfs mxm:   77.5509
+    bfs other  0.399522
+Xbc: setup for backtrack     0.192048
+starting 2nd phase
+Xbx 2nd phase: 34.0868
+    2nd mxm  : 33.2032
+    2nd other: 0.883555
+Xbc wrapup:    0.358273
+Xbc total:     113.126
+Batch    time: 1.131259e+02 (sec), rate: 12.9799 (1e6 edges/sec)
+
+Trial 4 : sources: [ 19524253 43676726 33055508 15244687 ]
+starting 1st phase
+Xbc setup 0.545612 sec
+Xbc bfs phase: 74.7368
+    bfs mxm:   74.3997
+    bfs other  0.337034
+Xbc: setup for backtrack     0.192165
+starting 2nd phase
+Xbx 2nd phase: 28.632
+    2nd mxm  : 27.9334
+    2nd other: 0.698571
+Xbc wrapup:    0.355364
+Xbc total:     104.462
+Batch    time: 1.044620e+02 (sec), rate: 14.0565 (1e6 edges/sec)
+
+Trial 5 : sources: [ 24946738 6479472 26077682 22023875 ]
+starting 1st phase
+Xbc setup 0.524211 sec
+Xbc bfs phase: 80.1368
+    bfs mxm:   79.6818
+    bfs other  0.454999
+Xbc: setup for backtrack      0.19371
+starting 2nd phase
+Xbx 2nd phase: 31.713
+    2nd mxm  : 30.7312
+    2nd other: 0.981731
+Xbc wrapup:    0.354026
+Xbc total:     112.922
+Batch    time: 1.129218e+02 (sec), rate: 13.0034 (1e6 edges/sec)
+
+Trial 6 : sources: [ 22081915 40034162 49496014 42847507 ]
+starting 1st phase
+Xbc setup 0.518987 sec
+Xbc bfs phase: 78.0686
+    bfs mxm:   77.7176
+    bfs other  0.350968
+Xbc: setup for backtrack     0.219738
+starting 2nd phase
+Xbx 2nd phase: 27.2167
+    2nd mxm  : 26.502
+    2nd other: 0.714749
+Xbc wrapup:    0.360322
+Xbc total:     106.384
+Batch    time: 1.063844e+02 (sec), rate: 13.8024 (1e6 edges/sec)
+
+Trial 7 : sources: [ 52409557 55445388 22028097 48766648 ]
+starting 1st phase
+Xbc setup 0.55071 sec
+Xbc bfs phase: 76.6563
+    bfs mxm:   76.2879
+    bfs other  0.368436
+Xbc: setup for backtrack     0.193788
+starting 2nd phase
+Xbx 2nd phase: 33.2088
+    2nd mxm  : 32.4303
+    2nd other: 0.778584
+Xbc wrapup:    0.355909
+Xbc total:     110.966
+Batch    time: 1.109656e+02 (sec), rate: 13.2326 (1e6 edges/sec)
+
+Trial 8 : sources: [ 44521241 60135542 28528671 9678012 ]
+starting 1st phase
+Xbc setup 0.531465 sec
+Xbc bfs phase: 78.8459
+    bfs mxm:   78.4231
+    bfs other  0.422851
+Xbc: setup for backtrack      0.21012
+starting 2nd phase
+Xbx 2nd phase: 23.8176
+    2nd mxm  : 22.9351
+    2nd other: 0.882506
+Xbc wrapup:    0.35492
+Xbc total:     103.76
+Batch    time: 1.037601e+02 (sec), rate: 14.1515 (1e6 edges/sec)
+
+Trial 9 : sources: [ 40020306 31625735 37446892 51788952 ]
+starting 1st phase
+Xbc setup 0.524405 sec
+Xbc bfs phase: 74.2156
+    bfs mxm:   73.7983
+    bfs other  0.417292
+Xbc: setup for backtrack     0.193017
+starting 2nd phase
+Xbx 2nd phase: 18.7411
+    2nd mxm  : 18.0964
+    2nd other: 0.64474
+Xbc wrapup:    0.355225
+Xbc total:     94.0294
+Batch    time: 9.402947e+01 (sec), rate: 15.616 (1e6 edges/sec)
+
+Trial 10 : sources: [ 52584255 20346696 48387909 37337427 ]
+starting 1st phase
+Xbc setup 0.521736 sec
+Xbc bfs phase: 79.1154
+    bfs mxm:   78.7411
+    bfs other  0.374297
+Xbc: setup for backtrack      0.19376
+starting 2nd phase
+Xbx 2nd phase: 27.042
+    2nd mxm  : 26.2425
+    2nd other: 0.799578
+Xbc wrapup:    0.356542
+Xbc total:     107.23
+Batch    time: 1.072296e+02 (sec), rate: 13.6937 (1e6 edges/sec)
+
+Trial 11 : sources: [ 50501084 30130061 41185893 56495703 ]
+starting 1st phase
+Xbc setup 0.533245 sec
+Xbc bfs phase: 78.4701
+    bfs mxm:   78.0869
+    bfs other  0.38319
+Xbc: setup for backtrack     0.193851
+starting 2nd phase
+Xbx 2nd phase: 34.4486
+    2nd mxm  : 33.5691
+    2nd other: 0.879499
+Xbc wrapup:    0.360973
+Xbc total:     114.007
+Batch    time: 1.140068e+02 (sec), rate: 12.8796 (1e6 edges/sec)
+
+Trial 12 : sources: [ 45663305 33359460 48143058 33291513 ]
+starting 1st phase
+Xbc setup 0.537062 sec
+Xbc bfs phase: 76.1107
+    bfs mxm:   75.723
+    bfs other  0.3877
+Xbc: setup for backtrack     0.193176
+starting 2nd phase
+Xbx 2nd phase: 34.259
+    2nd mxm  : 33.4335
+    2nd other: 0.825504
+Xbc wrapup:    0.357026
+Xbc total:     111.457
+Batch    time: 1.114570e+02 (sec), rate: 13.1743 (1e6 edges/sec)
+
+Trial 13 : sources: [ 53461445 29340610 34148498 49171806 ]
+starting 1st phase
+Xbc setup 0.541723 sec
+Xbc bfs phase: 75.7192
+    bfs mxm:   75.3058
+    bfs other  0.413394
+Xbc: setup for backtrack     0.208789
+starting 2nd phase
+Xbx 2nd phase: 24.6386
+    2nd mxm  : 23.8386
+    2nd other: 0.800069
+Xbc wrapup:    0.364036
+Xbc total:     101.472
+Batch    time: 1.014725e+02 (sec), rate: 14.4706 (1e6 edges/sec)
+
+Trial 14 : sources: [ 35550696 14521507 51633218 46823382 ]
+starting 1st phase
+Xbc setup 0.537033 sec
+Xbc bfs phase: 79.6287
+    bfs mxm:   79.2429
+    bfs other  0.385773
+Xbc: setup for backtrack     0.192709
+starting 2nd phase
+Xbx 2nd phase: 37.4449
+    2nd mxm  : 36.619
+    2nd other: 0.825876
+Xbc wrapup:    0.353673
+Xbc total:     118.157
+Batch    time: 1.181570e+02 (sec), rate: 12.4272 (1e6 edges/sec)
+
+Trial 15 : sources: [ 19396273 19871750 36862677 49539126 ]
+starting 1st phase
+Xbc setup 0.541138 sec
+Xbc bfs phase: 79.1052
+    bfs mxm:   78.6611
+    bfs other  0.444031
+Xbc: setup for backtrack     0.193054
+starting 2nd phase
+Xbx 2nd phase: 41.3751
+    2nd mxm  : 40.3855
+    2nd other: 0.989552
+Xbc wrapup:    0.36474
+Xbc total:     121.579
+Batch    time: 1.215792e+02 (sec), rate: 12.0774 (1e6 edges/sec)
+
+Trial 16 : sources: [ 34016452 36567395 55487793 14391370 ]
+starting 1st phase
+Xbc setup 0.540471 sec
+Xbc bfs phase: 73.3481
+    bfs mxm:   73.0389
+    bfs other  0.309264
+Xbc: setup for backtrack      0.19174
+starting 2nd phase
+Xbx 2nd phase: 24.813
+    2nd mxm  : 24.2039
+    2nd other: 0.609108
+Xbc wrapup:    0.359934
+Xbc total:     99.2533
+Batch    time: 9.925337e+01 (sec), rate: 14.7941 (1e6 edges/sec)
+ntrials: 16
+Average time per trial (batch):   108.937 sec
+build/bc_gap_test: all tests passed
+matrix: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+sources: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand_sources.mtx
+read time: 46.42 sec
+
+  134217728x134217728 GraphBLAS bool matrix, sparse by row:
+  A, 4294966740 entries
+
+    (0,8291853)   1
+    (0,9845139)   1
+    (0,14571172)   1
+    (0,16459757)   1
+    (0,27302127)   1
+    (0,27726180)   1
+    (0,30303523)   1
+    (0,32640525)   1
+    (0,33360373)   1
+    (0,40782998)   1
+    (0,41057943)   1
+    (0,43348321)   1
+    (0,50206206)   1
+    (0,52510658)   1
+    (0,53390371)   1
+    (0,53579654)   1
+    (0,54622695)   1
+    (0,57696071)   1
+    (0,59385788)   1
+    (0,60365539)   1
+    (0,64764501)   1
+    (0,64889445)   1
+    (0,72706136)   1
+    (0,77394182)   1
+    (0,82101150)   1
+    (0,86364056)   1
+    (0,86790574)   1
+    (0,90287459)   1
+    (0,104674459)   1
+    (0,109716228)   1
+    ...
+
+  64x1 GraphBLAS double matrix, sparse by row:
+  SourceNodes, 64 entries
+
+    (0,0)    27691420
+    (1,0)    121280315
+    (2,0)    2413432
+    (3,0)    37512114
+    (4,0)    38390878
+    (5,0)    56651038
+    (6,0)    128461249
+    (7,0)    33029843
+    (8,0)    71406329
+    (9,0)    117872828
+    (10,0)    24351939
+    (11,0)    15444520
+    (12,0)    127526282
+    (13,0)    112279429
+    (14,0)    13631650
+    (15,0)    110379303
+    (16,0)    44800624
+    (17,0)    77768194
+    (18,0)    175348
+    (19,0)    107397390
+    (20,0)    43457210
+    (21,0)    97215941
+    (22,0)    73575166
+    (23,0)    44449716
+    (24,0)    33931725
+    (25,0)    55526611
+    (26,0)    14422052
+    (27,0)    58043874
+    (28,0)    72137330
+    (29,0)    9647841
+    (30,0)    15940696
+    (31,0)    14209953
+    (32,0)    49020884
+    (33,0)    28901139
+    (34,0)    50493274
+    (35,0)    49150070
+    (36,0)    126525083
+    (37,0)    6382741
+    (38,0)    89108298
+    (39,0)    9239736
+    (40,0)    110168549
+    (41,0)    95370260
+    (42,0)    116653531
+    (43,0)    123410704
+    (44,0)    16733666
+    (45,0)    49030283
+    (46,0)    108545122
+    (47,0)    99095666
+    (48,0)    133850078
+    (49,0)    63499302
+    (50,0)    21541383
+    (51,0)    6230752
+    (52,0)    89077457
+    (53,0)    70392766
+    (54,0)    6670456
+    (55,0)    61746272
+    (56,0)    83349536
+    (57,0)    115272185
+    (58,0)    20129909
+    (59,0)    106148554
+    (60,0)    117042376
+    (61,0)    71431188
+    (62,0)    45287809
+    (63,0)    107702121
+
+setup time: 27.6634 sec
+A is symmetric
+transpose time: 81.1826
+
+========== input graph: nodes: 134217728 edges: 4294966740
+TESTING LAGraphX_bc_batch3 (saxpy in both phases, nthreads 40
+
+Trial 1 : sources: [ 27691419 121280314 2413431 37512113 ]
+starting 1st phase
+Xbc setup 1.13923 sec
+matrix: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+sources: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road_sources.mtx
+read time: 0.745218 sec
+
+  23947347x23947347 GraphBLAS bool matrix, sparse by row:
+  A, 57708624 entries
+
+    (0,1)   1
+    (0,709)   1
+    (0,1049673)   1
+    (1,0)   1
+    (1,2097154)   1
+    (2,9)   1
+    (2,2097152)   1
+    (2,2097156)   1
+    (3,1903)   1
+    (3,1048578)   1
+    (4,5)   1
+    (4,2097153)   1
+    (5,4)   1
+    (5,11)   1
+    (5,1048579)   1
+    (6,7)   1
+    (6,1048580)   1
+    (6,1048582)   1
+    (7,6)   1
+    (8,33976)   1
+    (8,1048581)   1
+    (9,2)   1
+    ...
+
+  64x1 GraphBLAS double matrix, sparse by row:
+  SourceNodes, 64 entries
+
+    (0,0)    4795721
+    (1,0)    21003854
+    (2,0)    417969
+    (3,0)    6496512
+    (4,0)    6648700
+    (5,0)    9811074
+    (6,0)    22247479
+    (7,0)    5720253
+    (8,0)    12366460
+    (9,0)    20413730
+    (10,0)    4217375
+    (11,0)    2674750
+    (12,0)    22085558
+    (13,0)    19445041
+    (14,0)    2360789
+    (15,0)    19115969
+    (16,0)    7758768
+    (17,0)    13468235
+    (18,0)    30368
+    (19,0)    18599548
+    (20,0)    7526109
+    (21,0)    16836281
+    (22,0)    12742068
+    (23,0)    7697996
+    (24,0)    5876444
+    (25,0)    9616341
+    (26,0)    2497674
+    (27,0)    10052291
+    (28,0)    12493058
+    (29,0)    1670856
+    (30,0)    2760680
+    (31,0)    2460942
+    (32,0)    8489651
+    (33,0)    5005226
+    (34,0)    8744646
+    (35,0)    8512024
+    (36,0)    21912166
+    (37,0)    1105391
+    (38,0)    15432164
+    (39,0)    1600178
+    (40,0)    19079470
+    (41,0)    16516638
+    (42,0)    20202567
+    (43,0)    21372804
+    (44,0)    2898010
+    (45,0)    8491278
+    (46,0)    18798318
+    (47,0)    23757561
+    (48,0)    17161820
+    (49,0)    23180740
+    (50,0)    10997086
+    (51,0)    3730631
+    (52,0)    1079069
+    (53,0)    15426823
+    (54,0)    12190926
+    (55,0)    1155219
+    (56,0)    10693489
+    (57,0)    14434836
+    (58,0)    19963340
+    (59,0)    3486186
+    (60,0)    18383270
+    (61,0)    20269909
+    (62,0)    12370765
+    (63,0)    7843141
+
+setup time: 0.639108 sec
+A is symmetric
+transpose time: 0.929723
+
+========== input graph: nodes: 23947347 edges: 57708624
+TESTING LAGraphX_bc_batch3 (saxpy in both phases, nthreads 40
+
+Trial 1 : sources: [ 4795720 21003853 417968 6496511 ]
+starting 1st phase
+Xbc setup 0.237658 sec
+Xbc bfs phase: 65.8063
+    bfs mxm:   42.4068
+    bfs other  23.3994
+Xbc: setup for backtrack    0.0772782
+starting 2nd phase
+Xbx 2nd phase: 27.9823
+    2nd mxm  : 26.5256
+    2nd other: 1.45674
+Xbc wrapup:    0.123531
+Xbc total:     94.2271
+Batch    time: 9.423183e+01 (sec), rate: 0.612411 (1e6 edges/sec)
+
+Trial 2 : sources: [ 6648699 9811073 22247478 5720252 ]
+starting 1st phase
+Xbc setup 0.216664 sec
+Xbc bfs phase: 68.8867
+    bfs mxm:   44.0043
+    bfs other  24.8824
+Xbc: setup for backtrack     0.076735
+starting 2nd phase
+Xbx 2nd phase: 29.7553
+    2nd mxm  : 28.322
+    2nd other: 1.43336
+Xbc wrapup:    0.121692
+Xbc total:     99.0571
+Batch    time: 9.906194e+01 (sec), rate: 0.582551 (1e6 edges/sec)
+
+Trial 3 : sources: [ 12366459 20413729 4217374 2674749 ]
+starting 1st phase
+Xbc setup 0.217324 sec
+Xbc bfs phase: 69.7946
+    bfs mxm:   44.3802
+    bfs other  25.4145
+Xbc: setup for backtrack     0.077901
+starting 2nd phase
+Xbx 2nd phase: 30.2856
+    2nd mxm  : 29.1323
+    2nd other: 1.15337
+Xbc wrapup:    0.124243
+Xbc total:     100.5
+Batch    time: 1.005047e+02 (sec), rate: 0.574188 (1e6 edges/sec)
+
+Trial 4 : sources: [ 22085557 19445040 2360788 19115968 ]
+starting 1st phase
+Xbc setup 0.215069 sec
+Xbc bfs phase: 69.3756
+    bfs mxm:   44.1834
+    bfs other  25.1922
+Xbc: setup for backtrack    0.0767099
+starting 2nd phase
+Xbx 2nd phase: 29.5506
+    2nd mxm  : 28.1682
+    2nd other: 1.38238
+Xbc wrapup:    0.126486
+Xbc total:     99.3445
+Batch    time: 9.934938e+01 (sec), rate: 0.580865 (1e6 edges/sec)
+
+Trial 5 : sources: [ 7758767 13468234 30367 18599547 ]
+starting 1st phase
+Xbc setup 0.239762 sec
+Xbc bfs phase: 67.2399
+    bfs mxm:   42.9962
+    bfs other  24.2437
+Xbc: setup for backtrack    0.0774973
+starting 2nd phase
+Xbx 2nd phase: 28.4415
+    2nd mxm  : 27.1604
+    2nd other: 1.28108
+Xbc wrapup:    0.122991
+Xbc total:     96.1217
+Batch    time: 9.612648e+01 (sec), rate: 0.600341 (1e6 edges/sec)
+
+Trial 6 : sources: [ 7526108 16836280 12742067 7697995 ]
+starting 1st phase
+Xbc setup 0.23467 sec
+Xbc bfs phase: 70.4768
+    bfs mxm:   44.1592
+    bfs other  26.3176
+Xbc: setup for backtrack    0.0934309
+starting 2nd phase
+Xbx 2nd phase: 31.1181
+    2nd mxm  : 29.7272
+    2nd other: 1.39092
+Xbc wrapup:    0.134367
+Xbc total:     102.057
+Batch    time: 1.020625e+02 (sec), rate: 0.565424 (1e6 edges/sec)
+
+Trial 7 : sources: [ 5876443 9616340 2497673 10052290 ]
+starting 1st phase
+Xbc setup 0.239505 sec
+Xbc bfs phase: 68.2899
+    bfs mxm:   43.412
+    bfs other  24.8779
+Xbc: setup for backtrack    0.0774353
+starting 2nd phase
+Xbx 2nd phase: 29.9475
+    2nd mxm  : 28.3438
+    2nd other: 1.60371
+Xbc wrapup:    0.124017
+Xbc total:     98.6784
+Batch    time: 9.868330e+01 (sec), rate: 0.584786 (1e6 edges/sec)
+
+Trial 8 : sources: [ 12493057 1670855 2760679 2460941 ]
+starting 1st phase
+Xbc setup 0.240343 sec
+Xbc bfs phase: 71.7605
+    bfs mxm:   44.8952
+    bfs other  26.8653
+Xbc: setup for backtrack     0.077357
+starting 2nd phase
+Xbx 2nd phase: 31.3567
+    2nd mxm  : 30.0005
+    2nd other: 1.35615
+Xbc wrapup:    0.125565
+Xbc total:     103.56
+Batch    time: 1.035655e+02 (sec), rate: 0.557219 (1e6 edges/sec)
+
+Trial 9 : sources: [ 8489650 5005225 8744645 8512023 ]
+starting 1st phase
+Xbc setup 0.263083 sec
+Xbc bfs phase: 61.9699
+    bfs mxm:   41.3076
+    bfs other  20.6623
+Xbc: setup for backtrack    0.0775472
+starting 2nd phase
+Xbx 2nd phase: 25.4499
+    2nd mxm  : 23.9508
+    2nd other: 1.49914
+Xbc wrapup:    0.121986
+Xbc total:     87.8824
+Batch    time: 8.788702e+01 (sec), rate: 0.656623 (1e6 edges/sec)
+
+Trial 10 : sources: [ 21912165 1105390 15432163 1600177 ]
+starting 1st phase
+Xbc setup 0.239351 sec
+Xbc bfs phase: 74.8849
+    bfs mxm:   47.6851
+    bfs other  27.1998
+Xbc: setup for backtrack    0.0772055
+starting 2nd phase
+Xbx 2nd phase: 32.5809
+    2nd mxm  : 31.2028
+    2nd other: 1.37807
+Xbc wrapup:    0.126135
+Xbc total:     107.908
+Batch    time: 1.079138e+02 (sec), rate: 0.534766 (1e6 edges/sec)
+
+Trial 11 : sources: [ 19079469 16516637 20202566 21372803 ]
+starting 1st phase
+Xbc setup 0.235488 sec
+Xbc bfs phase: 72.7214
+    bfs mxm:   45.4644
+    bfs other  27.257
+Xbc: setup for backtrack    0.0816103
+starting 2nd phase
+Xbx 2nd phase: 32.3138
+    2nd mxm  : 30.7608
+    2nd other: 1.55302
+Xbc wrapup:    0.125359
+Xbc total:     105.478
+Batch    time: 1.054828e+02 (sec), rate: 0.54709 (1e6 edges/sec)
+
+Trial 12 : sources: [ 2898009 8491277 18798317 23757560 ]
+starting 1st phase
+Xbc setup 0.235258 sec
+Xbc bfs phase: 67.5046
+    bfs mxm:   43.1924
+    bfs other  24.3122
+Xbc: setup for backtrack    0.0772265
+starting 2nd phase
+Xbx 2nd phase: 28.6121
+    2nd mxm  : 27.2779
+    2nd other: 1.33421
+Xbc wrapup:    0.126032
+Xbc total:     96.5553
+Batch    time: 9.656020e+01 (sec), rate: 0.597644 (1e6 edges/sec)
+
+Trial 13 : sources: [ 17161819 23180739 10997085 3730630 ]
+starting 1st phase
+Xbc setup 0.24001 sec
+Xbc bfs phase: 96.1337
+    bfs mxm:   57.9269
+    bfs other  38.2068
+Xbc: setup for backtrack    0.0837695
+starting 2nd phase
+Xbx 2nd phase: 137.838
+    2nd mxm  : 95.0544
+    2nd other: 42.7836
+Xbc wrapup:    0.12608
+Xbc total:     234.422
+Batch    time: 2.344285e+02 (sec), rate: 0.246167 (1e6 edges/sec)
+
+Trial 14 : sources: [ 1079068 15426822 12190925 1155218 ]
+starting 1st phase
+Xbc setup 0.22197 sec
+Xbc bfs phase: 85.3156
+    bfs mxm:   51.1358
+    bfs other  34.1798
+Xbc: setup for backtrack    0.0926268
+starting 2nd phase
+Xbx 2nd phase: 78.028
+    2nd mxm  : 50.2309
+    2nd other: 27.7971
+Xbc wrapup:    0.120242
+Xbc total:     163.779
+Batch    time: 1.637886e+02 (sec), rate: 0.352336 (1e6 edges/sec)
+
+Trial 15 : sources: [ 10693488 14434835 19963339 3486185 ]
+starting 1st phase
+Xbc setup 0.246608 sec
+Xbc bfs phase: 163.598
+    bfs mxm:   110.058
+    bfs other  53.5399
+Xbc: setup for backtrack     0.117399
+starting 2nd phase
+Xbx 2nd phase: 95.738
+    2nd mxm  : 60.6829
+    2nd other: 35.055
+Xbc wrapup:    0.128337
+Xbc total:     259.828
+Batch    time: 2.598376e+02 (sec), rate: 0.222095 (1e6 edges/sec)
+
+Trial 16 : sources: [ 18383269 20269908 12370764 7843140 ]
+starting 1st phase
+Xbc setup 0.272332 sec
+Xbc bfs phase: 83.9362
+    bfs mxm:   50.7866
+    bfs other  33.1497
+Xbc: setup for backtrack    0.0804605
+starting 2nd phase
+Xbx 2nd phase: 79.5838
+    2nd mxm  : 51.356
+    2nd other: 28.2278
+Xbc wrapup:    0.13042
+Xbc total:     164.003
+Batch    time: 1.640135e+02 (sec), rate: 0.351853 (1e6 edges/sec)
+ntrials: 16
+Average time per trial (batch):   125.844 sec
+build/bc_gap_test: all tests passed

--- a/Test/CC/2ndJan.out
+++ b/Test/CC/2ndJan.out
@@ -1,0 +1,110 @@
+matrix: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+number of threads: 1
+number of CCs: 123
+FastSV: 121.133794
+number of CCs: 123
+Boruvka: 189.677783
+
+number of threads: 4
+number of CCs: 123
+FastSV: 38.509867
+number of CCs: 123
+Boruvka: 58.612597
+
+number of threads: 16
+number of CCs: 123
+FastSV: 17.746928
+number of CCs: 123
+Boruvka: 27.047322
+
+number of threads: 20
+number of CCs: 123
+FastSV: 16.923298
+matrix: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+number of threads: 1
+number of CCs: 71164263
+FastSV: 1463.503211
+number of CCs: 71164263
+Boruvka: 1917.060959
+
+number of threads: 4
+matrix: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+number of threads: 1
+number of CCs: 19926186
+FastSV: 463.277754
+number of CCs: 19926186
+Boruvka: 455.673883
+
+number of threads: 4
+number of CCs: 19926186
+FastSV: 137.122000
+number of CCs: 19926186
+Boruvka: 138.265211
+
+number of threads: 16
+number of CCs: 19926186
+FastSV: 46.818400
+number of CCs: 19926186
+Boruvka: 47.943353
+
+number of threads: 20
+number of CCs: 19926186
+FastSV: 41.818149
+number of CCs: 19926186
+Boruvka: 43.001151
+
+number of threads: 40
+number of CCs: 19926186
+FastSV: 39.392845
+number of CCs: 19926186
+Boruvka: 41.448427
+
+matrix: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+number of threads: 1
+number of CCs: 1
+FastSV: 1495.081864
+number of CCs: 1
+Boruvka: 2322.043411
+
+number of threads: 4
+matrix: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+number of threads: 1
+number of CCs: 1
+FastSV: 49.694693
+number of CCs: 1
+Boruvka: 63.439479
+
+number of threads: 4
+number of CCs: 1
+FastSV: 16.627095
+number of CCs: 1
+Boruvka: 21.447160
+
+number of threads: 16
+number of CCs: 1
+FastSV: 8.922520
+number of CCs: 1
+Boruvka: 11.286769
+
+number of threads: 20
+number of CCs: 1
+FastSV: 8.609656
+number of CCs: 1
+Boruvka: 10.902780
+
+number of threads: 40
+number of CCs: 1
+FastSV: 8.337306
+number of CCs: 1
+Boruvka: 10.925793
+

--- a/Test/CC/do_gap
+++ b/Test/CC/do_gap
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./build/cctest ~/GAP/GAP-web/GAP-web.grb ~/GAP/GAP-web/GAP-web_sources.mtx
+./build/cctest ~/GAP/GAP-kron/GAP-kron.grb ~/GAP/GAP-kron/GAP-kron_sources.mtx
+./build/cctest ~/GAP/GAP-twitter/GAP-twitter.grb ~/GAP/GAP-twitter/GAP-twitter_sources.mtx
+./build/cctest ~/GAP/GAP-urand/GAP-urand.grb ~/GAP/GAP-urand/GAP-urand_sources.mtx
+./build/cctest ~/GAP/GAP-road/GAP-road.grb ~/GAP/GAP-road/GAP-road_sources.mtx
+

--- a/Test/TriangleCount/2ndJan.out
+++ b/Test/TriangleCount/2ndJan.out
@@ -1,0 +1,55 @@
+matrix: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-web/GAP-web.grb
+
+read A time:          14.207351 sec
+process A time:       21.858000 sec
+n 50636151 # edges 1810063330
+U=triu(A) time:        1.528777 sec
+L=tril(A) time:        1.544339 sec
+# of triangles: 84907041475
+nthreads:  40 time:    47.364237 rate:  38.22
+matrix: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-kron/GAP-kron.grb
+
+read A time:          33.121654 sec
+process A time:      110.066847 sec
+n 134217726 # edges 2111632322
+U=triu(A) time:        1.758616 sec
+L=tril(A) time:        1.777732 sec
+# of triangles: 106873365648
+nthreads:  40 time:  1673.080606 rate:   1.26
+matrix: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-twitter/GAP-twitter.grb
+
+read A time:          15.959971 sec
+process A time:       35.321517 sec
+n 61578415 # edges 1202513046
+U=triu(A) time:        1.105752 sec
+L=tril(A) time:        1.066049 sec
+# of triangles: 34824916864
+nthreads:  40 time:   564.346978 rate:   2.13
+matrix: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-urand/GAP-urand.grb
+
+read A time:          46.351311 sec
+process A time:      122.272966 sec
+n 134217728 # edges 2147483370
+U=triu(A) time:        2.373050 sec
+L=tril(A) time:        2.390477 sec
+# of triangles: 5378
+nthreads:  40 time:    33.129086 rate:  64.82
+matrix: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+[.grb]
+Reading binary file: /home/grads/a/aznaveh/GAP/GAP-road/GAP-road.grb
+
+read A time:           0.746062 sec
+process A time:        2.774976 sec
+n 23947347 # edges 28854312
+U=triu(A) time:        0.078968 sec
+L=tril(A) time:        0.077112 sec
+# of triangles: 438804
+nthreads:  40 time:     0.195089 rate: 147.90

--- a/Test/TriangleCount/do_gap
+++ b/Test/TriangleCount/do_gap
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./build/ttest ~/GAP/GAP-web/GAP-web.grb ~/GAP/GAP-web/GAP-web_sources.mtx
+./build/ttest ~/GAP/GAP-kron/GAP-kron.grb ~/GAP/GAP-kron/GAP-kron_sources.mtx
+./build/ttest ~/GAP/GAP-twitter/GAP-twitter.grb ~/GAP/GAP-twitter/GAP-twitter_sources.mtx
+./build/ttest ~/GAP/GAP-urand/GAP-urand.grb ~/GAP/GAP-urand/GAP-urand_sources.mtx
+./build/ttest ~/GAP/GAP-road/GAP-road.grb ~/GAP/GAP-road/GAP-road_sources.mtx
+


### PR DESCRIPTION
I have added reading binary to TC, BFS and CC. create do_gap script and run it on hypersparse and save the result on 2ndJan.out
I run the gap for BC too and decided to keep the result anyway