### PR TITLE
fastsv5b: parallelize Reduce_assign()

### DIFF
--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -901,6 +901,12 @@ GrB_Info LAGraph_cc_fastsv5a (
     bool sanitize           // if true, ensure A is symmetric
 ) ;
 
+GrB_Info LAGraph_cc_fastsv5b (
+    GrB_Vector *result,     // output: array of component identifiers
+    GrB_Matrix *A,          // input matrix
+    bool sanitize           // if true, ensure A is symmetric
+) ;
+
 GrB_Info LAGraph_cc_boruvka (
     GrB_Vector *result,     // output: array of component identifiers
     GrB_Matrix A,           // input matrix


### PR DESCRIPTION
Parallelize the `Reduce_assign()` function
- Only the duplicates on selected indices are summed with an accumulator. Those indices are randomly sampled so that frequently occurred indices are likely to be selected.
- Each thread writes to the output vector in parallel except on those selected indices, whose values are stored in each thread's individual buffer. The buffers are merged after the parallel loop.
- The selected indices are put into a hash table.
- The behavior of this function differs from the previous version and also differs from `LAGr_assign()`. The output of `Reduce_assign()` is now nondeterministic, but FastSV can tolerate this nondeterminism and the result is still correct.

Skip the first execution of `Reduce_assign()` since it is equivalent to `f=mngp` and is redundant.
.