### PR TITLE
guard malloc.h include when not on linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - sudo ldconfig
   - cd ..
   # LAGraph
-  - git clone --depth 1 --branch ${TRAVIS_COMMIT} https://github.com/${TRAVIS_REPO_SLUG}
+  - git clone --depth 1 --branch ${TRAVIS_BRANCH} https://github.com/${TRAVIS_REPO_SLUG}
   - cd LAGraph
   - JOBS=$(nproc) make
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,25 @@
-services:
-  - docker
-
+# based on travis.yml from graphalytics
+language: c
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+#    - os: osx
+#      osx_image: xcode11.3
+install:
+  # GraphBLAS
+  - git clone --depth 1 --branch v3.2.0 https://github.com/DrTimothyAldenDavis/GraphBLAS
+  - cd GraphBLAS
+  - JOBS=$(nproc) make
+  - sudo make install
+  - sudo ldconfig
+  - cd ..
+  # LAGraph
+  - git clone --depth 1 --branch ${TRAVIS_COMMIT} https://github.com/${TRAVIS_REPO_SLUG}
+  - cd LAGraph
+  - JOBS=$(nproc) make
+  - sudo make install
+  - sudo ldconfig
+  - cd ..
 script:
-  - docker build -t graphblas/lagraph:${TRAVIS_COMMIT} .
-  - docker run -w /LAGraph -it graphblas/lagraph:${TRAVIS_COMMIT} make tests
-
+  - make tests

--- a/Source/Utility/LAGraph_init.c
+++ b/Source/Utility/LAGraph_init.c
@@ -40,7 +40,11 @@
 // See also LAGraph_xinit.
 
 #include "LAGraph_internal.h"
+#ifdef __linux__
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 // #include <gnu/libc-version.h>
 
 GrB_Info LAGraph_init ( )


### PR DESCRIPTION
Guard malloc.h include which is removed from osx 10.14 persumably, I can't test it, but this change works on linux.  The mallopt call is already guarded.  Does anyone have a new mac to test this on? @szarnyasg perhaps?