### PR TITLE
Support OS X on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,21 @@ jobs:
   include:
     - os: linux
       dist: bionic
-#    - os: osx
-#      osx_image: xcode11.3
+    - os: osx
+      osx_image: xcode11.3
 install:
-  # GraphBLAS
-  - git clone --depth 1 --branch v3.2.0 https://github.com/DrTimothyAldenDavis/GraphBLAS
-  - cd GraphBLAS
-  - JOBS=$(nproc) make
-  - sudo make install
-  - sudo ldconfig
+  # clone GraphBLAS next to LAGraph's directory
+  - pushd .
   - cd ..
-  # LAGraph
-  - git clone --depth 1 --branch ${TRAVIS_BRANCH} https://github.com/${TRAVIS_REPO_SLUG}
-  - cd LAGraph
-  - JOBS=$(nproc) make
-  - sudo make install
-  - sudo ldconfig
-  - cd ..
+  - git clone --depth 1 --branch master https://github.com/DrTimothyAldenDavis/GraphBLAS
+  - cd GraphBLAS/build
+  - cmake -DGBCOMPACT=1 -DCMAKE_C_FLAGS="$(CMAKE_C_FLAGS) -w" ..
+  - JOBS=2 make
+  - popd
 script:
+  # build and test LAGraph
+  - cd build
+  - cmake ..
+  - JOBS=2 make
+  - cd ..
   - make tests

--- a/Source/Utility/LAGraph_complex.c
+++ b/Source/Utility/LAGraph_complex.c
@@ -54,8 +54,8 @@ GrB_Type LAGraph_ComplexFP64 = NULL ;
 #define Y *y
 #define Z *z
 
-#define ONE  CMPLX(1,0)
-#define ZERO CMPLX(0,0)
+#define ONE  (CMPLX(1.0,0.0))
+#define ZERO (CMPLX(0.0,0.0))
 #define T ONE
 #define F ZERO
 #define BOOL(X) (X != ZERO)

--- a/Test/Complex/complextest.c
+++ b/Test/Complex/complextest.c
@@ -128,10 +128,10 @@
     J));                                        \
   }                                             \
 
-#define ZERO CMPLX(0, 0)
-#define ONE CMPLX(1, 0)
-#define LL CMPLX(1.0, 1.0)
-#define RR CMPLX(2.0, 2.0)
+#define ZERO (CMPLX(0.0,0.0))
+#define ONE (CMPLX(1.0,0.0))
+#define LL (CMPLX(1.0,1.0))
+#define RR (CMPLX(2.0,2.0))
 
 #define TEST_BINOP(L, R, OP, V)                             \
   {                                                         \
@@ -301,13 +301,13 @@ int main (int argc, char **argv)
     TEST_BINOP(LL, RR, LAGraph_MIN_ComplexFP64, LL);
     TEST_BINOP(LL, RR, LAGraph_FIRST_ComplexFP64, LL);
     TEST_BINOP(LL, RR, LAGraph_SECOND_ComplexFP64, RR);
-    TEST_BINOP(LL, RR, LAGraph_PLUS_ComplexFP64, CMPLX(3, 3));
-    TEST_BINOP(LL, RR, LAGraph_MINUS_ComplexFP64, CMPLX(-1, -1));
+    TEST_BINOP(LL, RR, LAGraph_PLUS_ComplexFP64, (CMPLX(3, 3)));
+    TEST_BINOP(LL, RR, LAGraph_MINUS_ComplexFP64, (CMPLX(-1, -1)));
     TEST_BINOP(LL, RR, LAGraph_RMINUS_ComplexFP64, LL);
-    TEST_BINOP(LL, RR, LAGraph_TIMES_ComplexFP64, CMPLX(0, 4));
-    TEST_BINOP(LL, RR, LAGraph_DIV_ComplexFP64, CMPLX(0.5, 0));
-    TEST_BINOP(LL, RR, LAGraph_RDIV_ComplexFP64, CMPLX(2, 0));
-    TEST_BINOP(LL, RR, LAGraph_PAIR_ComplexFP64, CMPLX(1, 0));
+    TEST_BINOP(LL, RR, LAGraph_TIMES_ComplexFP64, (CMPLX(0, 4)));
+    TEST_BINOP(LL, RR, LAGraph_DIV_ComplexFP64, (CMPLX(0.5, 0)));
+    TEST_BINOP(LL, RR, LAGraph_RDIV_ComplexFP64, (CMPLX(2, 0)));
+    TEST_BINOP(LL, RR, LAGraph_PAIR_ComplexFP64, (CMPLX(1, 0)));
     TEST_BINOP(LL, RR, LAGraph_ANY_ComplexFP64, RR);
     TEST_BINOP(LL, RR, LAGraph_ISEQ_ComplexFP64, ZERO);
     TEST_BINOP(LL, RR, LAGraph_ISNE_ComplexFP64, ONE);
@@ -321,11 +321,11 @@ int main (int argc, char **argv)
 
     TEST_UOP(LL, LAGraph_ONE_ComplexFP64, ONE);
     TEST_UOP(RR, LAGraph_IDENTITY_ComplexFP64, RR);
-    TEST_UOP(RR, LAGraph_AINV_ComplexFP64, CMPLX(-2, -2));
-    TEST_UOP(CMPLX(-2, 0), LAGraph_ABS_ComplexFP64, CMPLX(2, 0));
-    TEST_UOP(CMPLX(-2, 0), LAGraph_MINV_ComplexFP64, CMPLX(-0.5, -0));
-    TEST_UOP(CMPLX(-2, 0), LAGraph_NOT_ComplexFP64, CMPLX(0, 0));
-    TEST_UOP(CMPLX(-2, 2), LAGraph_CONJ_ComplexFP64, CMPLX(-2, -2));
+    TEST_UOP(RR, LAGraph_AINV_ComplexFP64, (CMPLX(-2, -2)));
+    TEST_UOP((CMPLX(-2, 0)), LAGraph_ABS_ComplexFP64, (CMPLX(2, 0)));
+    TEST_UOP((CMPLX(-2, 0)), LAGraph_MINV_ComplexFP64, (CMPLX(-0.5, -0)));
+    TEST_UOP((CMPLX(-2, 0)), LAGraph_NOT_ComplexFP64, (CMPLX(0, 0)));
+    TEST_UOP((CMPLX(-2, 2)), LAGraph_CONJ_ComplexFP64, (CMPLX(-2, -2)));
 
     OK(GrB_free(&C));
     OK(GrB_Matrix_new
@@ -339,17 +339,17 @@ int main (int argc, char **argv)
     TEST_BINOP_BOOL(LL, RR, LAGraph_LE_ComplexFP64, true);
     TEST_BINOP_BOOL(LL, RR, LAGraph_SKEW_ComplexFP64, false);
     TEST_BINOP_BOOL(LL, RR, LAGraph_HERMITIAN_ComplexFP64, false);
-    TEST_UOP_BOOL(CMPLX(1, 0), LAGraph_ISONE_ComplexFP64, true);
-    TEST_UOP_BOOL(CMPLX(-2, 2), LAGraph_TRUE_BOOL_ComplexFP64, true);
+    TEST_UOP_BOOL((CMPLX(1, 0)), LAGraph_ISONE_ComplexFP64, true);
+    TEST_UOP_BOOL((CMPLX(-2, 2)), LAGraph_TRUE_BOOL_ComplexFP64, true);
 
     OK(GrB_free(&C));
     OK(GrB_Matrix_new
        (&C, GrB_FP64, 2, 2)) ;
 
-    TEST_UOP_DOUBLE(CMPLX(-2, 0), LAGraph_REAL_ComplexFP64, -2);
-    TEST_UOP_DOUBLE(CMPLX(-2, 2), LAGraph_IMAG_ComplexFP64, 2);
-    TEST_UOP_DOUBLE(CMPLX(-2, 0), LAGraph_CABS_ComplexFP64, 2);
-    TEST_UOP_DOUBLE(CMPLX(1, 0), LAGraph_ANGLE_ComplexFP64, 0);
+    TEST_UOP_DOUBLE((CMPLX(-2, 0)), LAGraph_REAL_ComplexFP64, -2);
+    TEST_UOP_DOUBLE((CMPLX(-2, 2)), LAGraph_IMAG_ComplexFP64, 2);
+    TEST_UOP_DOUBLE((CMPLX(-2, 0)), LAGraph_CABS_ComplexFP64, 2);
+    TEST_UOP_DOUBLE((CMPLX(1, 0)), LAGraph_ANGLE_ComplexFP64, 0);
 
     OK(GrB_free(&A));
     OK(GrB_Matrix_new


### PR DESCRIPTION
Based on @michelp's work in PR #73 and continuing the work of PR #70. The build now uses the `-DGBCOMPACT` flag, introduced in the latest SuiteSparse:GraphBLAS (after v3.2.0) which cuts compile time considerably.

In my fork, this branch compiled for both OS X (~10 minutes) and Ubuntu (~5 minutes). An important change is the addition of parentheses around `CMPLX` macros. When omitting these, the OS X build fails as follows:

![image](https://user-images.githubusercontent.com/1402801/75822774-cc2eef80-5da0-11ea-8a41-313ee0465947.png)
