### PR TITLE
Dense vertex relabeling

### DIFF
--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -1234,12 +1234,14 @@ GrB_Info LAGraph_cdlp           // compute cdlp for all nodes in A
                                 // in seconds
 ) ;
 
-GrB_Info LAGraph_dense_relabel   // compute dense relabel
+GrB_Info LAGraph_dense_relabel   // relabel sparse IDs to dense row/column indices
 (
-    GrB_Matrix *MMapping_handle, // output matrix with the mapping (unfilled if NULL)
-    GrB_Vector *VMapping_handle, // output vector with the mapping (unfilled if NULL)
-    const GrB_Index *ids,        // array of identifiers
-    GrB_Index nids               // number of identifiers
+    GrB_Matrix *Id2index_handle, // output matrix: A(id, index)=1 (unfilled if NULL)
+    GrB_Matrix *Index2id_handle, // output matrix: B(index, id)=1 (unfilled if NULL)
+    GrB_Vector *id2index_handle, // output vector: v(id)=index (unfilled if NULL)
+    const GrB_Index *ids,        // array of unique identifiers (under GB_INDEX_MAX=2^60)
+    GrB_Index nids,              // number of identifiers
+    GrB_Index *id_dimension      // number of rows in Id2index matrix, id2index vector (unfilled if NULL)
 ) ;
 
 GrB_Info LAGraph_dnn    // returns GrB_SUCCESS if successful

--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -1238,8 +1238,8 @@ GrB_Info LAGraph_dense_relabel   // compute dense relabel
 (
     GrB_Matrix *MMapping_handle, // output matrix with the mapping (unfilled if NULL)
     GrB_Vector *VMapping_handle, // output vector with the mapping (unfilled if NULL)
-    const GrB_Index nids,        // number of identifiers
-    const GrB_Index *ids         // array of identifiers
+    const GrB_Index *ids,        // array of identifiers
+    GrB_Index nids               // number of identifiers
 ) ;
 
 GrB_Info LAGraph_dnn    // returns GrB_SUCCESS if successful

--- a/Include/LAGraph.h
+++ b/Include/LAGraph.h
@@ -1234,6 +1234,14 @@ GrB_Info LAGraph_cdlp           // compute cdlp for all nodes in A
                                 // in seconds
 ) ;
 
+GrB_Info LAGraph_dense_relabel   // compute dense relabel
+(
+    GrB_Matrix *MMapping_handle, // output matrix with the mapping (unfilled if NULL)
+    GrB_Vector *VMapping_handle, // output vector with the mapping (unfilled if NULL)
+    const GrB_Index nids,        // number of identifiers
+    const GrB_Index *ids         // array of identifiers
+) ;
+
 GrB_Info LAGraph_dnn    // returns GrB_SUCCESS if successful
 (
     // output

--- a/Source/Algorithm/LAGraph_dense_relabel.c
+++ b/Source/Algorithm/LAGraph_dense_relabel.c
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// LAGraph_dense_relabel: dense relabeling of ids to matrix indices
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// LAGraph_dense_relabel: Contributed by Marton Elekes and Gabor Szarnyas,
+// Budapest University of Technology and Economics
+// (with accented characters: M\'{a}rton Elekes and G\'{a}bor Sz\'{a}rnyas.
+
+// ...
+
+#include "LAGraph_internal.h"
+
+#define LAGRAPH_FREE_ALL            \
+{                                   \
+}
+
+//------------------------------------------------------------------------------
+
+GrB_Info LAGraph_dense_relabel   // compute dense relabel
+(
+    GrB_Matrix *MMapping_handle, // output matrix with the mapping (unfilled if NULL)
+    GrB_Vector *VMapping_handle, // output vector with the mapping (unfilled if NULL)
+    const GrB_Index nids,        // number of identifiers
+    const GrB_Index *ids         // array of identifiers
+)
+{
+
+    //--------------------------------------------------------------------------
+    // check inputs
+    //--------------------------------------------------------------------------
+
+    if (MMapping_handle == NULL && VMapping_handle == NULL)
+    {
+        LAGRAPH_ERROR ("Both mapping arguments are NULL", GrB_NULL_POINTER) ;
+    }
+
+    GrB_Info info ;
+
+    // ... TODO
+
+    return (GrB_SUCCESS) ;
+}
+

--- a/Source/Algorithm/LAGraph_dense_relabel.c
+++ b/Source/Algorithm/LAGraph_dense_relabel.c
@@ -47,7 +47,7 @@
 //   id_dimension is the size that can store the largest ID in the array.
 //   Currently it is the largest valid dimension in SuiteSparse:GraphBLAS (GB_INDEX_MAX = 2^60)
 //
-// Find usage example in /Test/DenseRelabel/denserelabeltest.c
+// Find usage example in /Test/DenseRelabel/dense_relabel_test.c
 
 #include "LAGraph_internal.h"
 #include <string.h>

--- a/Test/DenseRelabel/.gitignore
+++ b/Test/DenseRelabel/.gitignore
@@ -1,0 +1,5 @@
+# Ignore these files
+stderr.txt
+
+# Do not ignore this file
+!.gitignore

--- a/Test/DenseRelabel/CMakeLists.txt
+++ b/Test/DenseRelabel/CMakeLists.txt
@@ -1,0 +1,213 @@
+#-------------------------------------------------------------------------------
+# LAGraph/Test/DenseRelabel/CMakeLists.txt:  cmake script for LAGraph test
+#-------------------------------------------------------------------------------
+
+# LAGraph, (... list all authors here) (c) 2019, All Rights Reserved.
+# http://lagraph.org  See LAGraph/LICENSE for license.
+
+# CMakeLists.txt: instructions for cmake to build LAGraph.
+# An ANSI C11 compiler is required.
+#
+# First, install any GraphBLAS library.
+# Alternatively, use ../GraphBLAS (see comments below).
+#
+# To compile and install the LAGraph library:
+#
+#   make
+#   sudo make install
+#
+# Then to compile and run the Demos:
+# 
+#   cd Demos
+#   make
+#
+# If that fails for any reason, make sure your compiler supports ANSI C11.  You
+# could try changing your compiler, for example:
+#
+#   cd build
+#   CC=icc cmake ..
+#   cd ..
+#   make
+#
+# Or, with other compilers:
+#
+#   CC=xlc cmake ..
+#   CC=gcc cmake ..
+#
+# To remove all compiled files and libraries (except installed ones):
+#
+#   make distclean
+
+#-------------------------------------------------------------------------------
+# get the version
+#-------------------------------------------------------------------------------
+
+# cmake 3.0 is preferred.
+cmake_minimum_required ( VERSION 2.8.12 )
+
+if ( CMAKE_VERSION VERSION_GREATER "3.0" )
+    cmake_policy ( SET CMP0042 NEW )
+    cmake_policy ( SET CMP0048 NEW )
+endif ( )
+
+project ( BF_test )
+
+#-------------------------------------------------------------------------------
+# determine build type
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+# For development only, not for end-users:
+# set ( CMAKE_BUILD_TYPE Debug )
+
+if ( NOT CMAKE_BUILD_TYPE )
+    set ( CMAKE_BUILD_TYPE Release )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# edit these lines to select your GraphBLAS library
+#-------------------------------------------------------------------------------
+
+# link_directories ( /usr/local/lib )
+link_directories ( ../../../GraphBLAS/build )
+link_directories ( ../../build )
+
+# include_directories ( /usr/local/include )
+include_directories ( ../../../GraphBLAS/Include )
+include_directories ( ../../Include )
+
+#-------------------------------------------------------------------------------
+# determine what user threading model to use
+#-------------------------------------------------------------------------------
+
+include ( FindOpenMP  )
+include ( FindThreads )
+
+#-------------------------------------------------------------------------------
+# report status
+#-------------------------------------------------------------------------------
+
+message ( STATUS "CMAKE build type:          " ${CMAKE_BUILD_TYPE} )
+
+if ( ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message ( STATUS "CMAKE C Flags debug:       " ${CMAKE_C_FLAGS_DEBUG} )
+else ( )
+    message ( STATUS "CMAKE C Flags release:     " ${CMAKE_C_FLAGS_RELEASE} )
+endif ( )
+
+message ( STATUS "CMAKE compiler ID:         " ${CMAKE_C_COMPILER_ID} )
+message ( STATUS "CMAKE thread library:      " ${CMAKE_THREAD_LIBS_INIT} )
+message ( STATUS "CMAKE have pthreads:       " ${CMAKE_USE_PTHREADS_INIT}  )
+message ( STATUS "CMAKE have Win32 pthreads: " ${CMAKE_USE_WIN32_THREADS_INIT} )
+message ( STATUS "CMAKE have OpenMP:         " ${OPENMP_FOUND} )
+
+#-------------------------------------------------------------------------------
+# include directories
+#-------------------------------------------------------------------------------
+
+set ( CMAKE_INCLUDE_CURRENT_DIR ON )
+
+#-------------------------------------------------------------------------------
+# compiler options
+#-------------------------------------------------------------------------------
+
+# check which compiler is being used.  If you need to make
+# compiler-specific modifications, here is the place to do it.
+if ( "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    # cmake 2.8 workaround: gcc needs to be told to do ANSI C11.
+    # cmake 3.0 doesn't have this problem.
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -std=c11 -lm -Wno-pragmas " )
+    # check all warnings:
+#   set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -Werror " )
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 4.9 )
+        message ( FATAL_ERROR "gcc version must be at least 4.9" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Intel" )
+    # options for icc: also needs -std=c11
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -std=c11 " )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -qopt-malloc-options=3" )
+    # check all warnings:
+#   set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -w3 " )
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 18.0 )
+        message ( FATAL_ERROR "icc version must be at least 18.0" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
+    # options for clang
+    if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 3.3 )
+        message ( FATAL_ERROR "clang version must be at least 3.3" )
+    endif ( )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" )
+    # options for MicroSoft Visual Studio
+endif ( )
+
+if ( ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}" )
+else ( )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}" )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# select the threading library 
+#-------------------------------------------------------------------------------
+
+if ( USER_OPENMP )
+    # user insists on OpenMP synchronization inside LAGraph
+    message ( STATUS "cmake -DUSER_OPENMP=1: insisting on using OpenMP" )
+    set ( USE_OPENMP true )
+elseif ( USER_POSIX )
+    # user insists on POSIX synchronization inside LAGraph
+    message ( STATUS "cmake -DUSER_POSIX=1: insisting on using POSIX" )
+    set ( USE_POSIX true )
+elseif ( USER_NONE )
+    message ( STATUS "cmake -DUSER_NONE=1: insisting on using no threading" )
+    set ( USE_NONE true )
+else ( )
+    # default: automatic selection
+    message ( STATUS "Automatic selection of synchronization method" )
+    if ( OPENMP_FOUND )
+        set ( USE_OPENMP true )
+    elseif ( CMAKE_USE_PTHREADS_INIT )
+        set ( USE_POSIX true )
+    endif ( )
+endif ( )
+
+# add the threading library
+if ( USE_OPENMP )
+    # use OpenMP
+    message ( STATUS "Using OpenMP to synchronize user threads" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -DUSER_OPENMP_THREADS " )
+elseif ( USE_POSIX )
+    # use POSIX
+    message ( STATUS "Using POSIX pthreads to synchronize user threads" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -pthread -DUSER_POSIX_THREADS " )
+else ( )
+    # use no threading at all
+    message ( WARNING "No support for user threads; LAGraph will not be thread-safe" )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DUSER_NO_THREADS " )
+endif ( )
+
+if ( CMAKE_USE_PTHREADS_INIT )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_PTHREADS " )
+endif ( )
+
+if ( CMAKE_USE_WIN32_THREADS_INIT )
+    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DHAVE_WINDOWS_THREADS " )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# print final C flags
+#-------------------------------------------------------------------------------
+
+message ( STATUS "CMAKE C flags: " ${CMAKE_C_FLAGS} )
+
+#-------------------------------------------------------------------------------
+# Demo programs
+#-------------------------------------------------------------------------------
+
+file ( GLOB SOURCES "*.c" )
+
+add_executable ( dense_relabel_test ${SOURCES} )
+
+# Libraries required for Demo programs
+target_link_libraries ( dense_relabel_test graphblas lagraph m )

--- a/Test/DenseRelabel/Makefile
+++ b/Test/DenseRelabel/Makefile
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------
+# Test/DenseRelabel/Makefile
+#-------------------------------------------------------------------------------
+
+# LAGraph, (... list all authors here) (c) 2019, All Rights Reserved.
+# http://graphblas.org  See LAGraph/LICENSE for license.
+
+#-------------------------------------------------------------------------------
+
+# simple Makefile for LAGraph/Test/DenseRelabel/denserelabeltest
+
+# relies on cmake to do the actual build.  Use the CMAKE_OPTIONS argument to
+# this Makefile to pass options to cmake.
+
+# Install LAGraph and GraphBLAS before trying to compile LAGraph.
+
+JOBS ?= 1
+
+# build and run test
+default: compile
+	./build/lcctest ../../Data/ldbc-directed-example-unweighted.mtx 0
+	./build/lcctest ../../Data/ldbc-undirected-example-unweighted.mtx 1
+
+# build test
+compile:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) --jobs=$(JOBS) )
+
+# just run cmake; do not compile
+cmake:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; )
+
+clean: distclean
+
+purge: distclean
+
+# remove all files not in the distribution
+distclean:
+	rm -rf build/* stderr.txt
+

--- a/Test/DenseRelabel/Makefile
+++ b/Test/DenseRelabel/Makefile
@@ -18,8 +18,7 @@ JOBS ?= 1
 
 # build and run test
 default: compile
-	./build/lcctest ../../Data/ldbc-directed-example-unweighted.mtx 0
-	./build/lcctest ../../Data/ldbc-undirected-example-unweighted.mtx 1
+	./build/denserelabeltest
 
 # build test
 compile:

--- a/Test/DenseRelabel/Makefile
+++ b/Test/DenseRelabel/Makefile
@@ -7,7 +7,7 @@
 
 #-------------------------------------------------------------------------------
 
-# simple Makefile for LAGraph/Test/DenseRelabel/denserelabeltest
+# simple Makefile for LAGraph/Test/DenseRelabel/dense_relabel_test
 
 # relies on cmake to do the actual build.  Use the CMAKE_OPTIONS argument to
 # this Makefile to pass options to cmake.
@@ -18,7 +18,7 @@ JOBS ?= 1
 
 # build and run test
 default: compile
-	./build/denserelabeltest
+	./build/dense_relabel_test
 
 # build test
 compile:

--- a/Test/DenseRelabel/build/.gitignore
+++ b/Test/DenseRelabel/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files here except this file.
+*
+*/
+!.gitignore

--- a/Test/DenseRelabel/dense_relabel_test.c
+++ b/Test/DenseRelabel/dense_relabel_test.c
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// LAGraph/Test/DenseRelabel/denserelabeltest.c: test program for LAGraph_dense_relabel
+// LAGraph/Test/DenseRelabel/dense_relabel_test.c: test program for LAGraph_dense_relabel
 //------------------------------------------------------------------------------
 
 /*
@@ -38,7 +38,7 @@
 
 // Usage:
 //
-// denserelabeltest
+// dense_relabel_test
 
 #include "LAGraph.h"
 

--- a/Test/DenseRelabel/denserelabeltest.c
+++ b/Test/DenseRelabel/denserelabeltest.c
@@ -1,0 +1,65 @@
+//------------------------------------------------------------------------------
+// LAGraph/Test/DenseRelabel/denserelabeltest.c: test program for LAGraph_dense_relabel
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// Contributed by Marton Elekes and Gabor Szarnyas, BME
+
+// Usage:
+//
+// denserelabeltest
+
+#include "LAGraph.h"
+
+#define LAGRAPH_FREE_ALL                            \
+{                                                   \
+}
+
+int main (int argc, char **argv)
+{
+
+    //--------------------------------------------------------------------------
+    // initialize LAGraph and GraphBLAS
+    //--------------------------------------------------------------------------
+
+    GrB_Info info ;
+
+    LAGraph_init ( ) ;
+
+    printf("TODO\n");
+
+    LAGRAPH_FREE_ALL ;
+    LAGraph_finalize ( ) ;
+}
+

--- a/Test/DenseRelabel/denserelabeltest.c
+++ b/Test/DenseRelabel/denserelabeltest.c
@@ -42,24 +42,40 @@
 
 #include "LAGraph.h"
 
-#define LAGRAPH_FREE_ALL                            \
-{                                                   \
+#include <inttypes.h>
+
+#define LAGRAPH_FREE_ALL            \
+{                                   \
+    GrB_free (&MMapping) ;          \
+    GrB_free (&VMapping) ;          \
 }
 
-int main (int argc, char **argv)
-{
+int main(int argc, char **argv) {
 
     //--------------------------------------------------------------------------
     // initialize LAGraph and GraphBLAS
     //--------------------------------------------------------------------------
 
-    GrB_Info info ;
+    GrB_Info info;
+    GrB_Matrix MMapping = NULL;
+    GrB_Vector VMapping = NULL;
 
-    LAGraph_init ( ) ;
+    LAGRAPH_OK (LAGraph_init());
 
-    printf("TODO\n");
+    GrB_Index big_id = ((GrB_Index) 1) << 48;
+    GrB_Index identifiers[] = {42, 0, big_id, 1};
+    GrB_Index nids = sizeof(identifiers) / sizeof(identifiers[0]);
 
-    LAGRAPH_FREE_ALL ;
-    LAGraph_finalize ( ) ;
+    for (size_t i = 0; i < nids; ++i) {
+        printf("%" PRIu64 "\n", identifiers[i]);
+    }
+
+    LAGRAPH_OK(LAGraph_dense_relabel(&MMapping, &VMapping, identifiers, nids));
+
+    LAGRAPH_OK(GxB_fprint(MMapping, GxB_COMPLETE, stdout));
+    LAGRAPH_OK(GxB_fprint(VMapping, GxB_COMPLETE, stdout));
+
+
+    LAGRAPH_FREE_ALL;
+    LAGraph_finalize();
 }
-

--- a/Test/Makefile
+++ b/Test/Makefile
@@ -31,6 +31,7 @@ default:
 	( cd MatrixMarket          ; $(MAKE) --jobs=$(JOBS) CC=$(CC) CXX=$(CC) )
 	( cd BuildMatrix           ; $(MAKE) --jobs=$(JOBS) CC=$(CC) CXX=$(CC) )
 	( cd BinRead               ; $(MAKE) --jobs=$(JOBS) CC=$(CC) CXX=$(CC) )
+	( cd DenseRelabel          ; $(MAKE) --jobs=$(JOBS) CC=$(CC) CXX=$(CC) )
 	( cd SSSP                  ; $(MAKE) --jobs=$(JOBS) CC=$(CC) CXX=$(CC) )
 
 clean: distclean
@@ -53,5 +54,6 @@ distclean:
 	( cd MatrixMarket          ; $(MAKE) distclean )
 	( cd BuildMatrix           ; $(MAKE) distclean )
 	( cd BinRead               ; $(MAKE) distclean )
+	( cd DenseRelabel          ; $(MAKE) distclean )
 	( cd SSSP                  ; $(MAKE) distclean )
 


### PR DESCRIPTION
This PR adds `LAGraph_dense_relabel`, which provides vector and matrix for conversion between sparse IDs and dense row/column indices (0..n-1) as discussed on [GraphBLAS mailing list](https://groups.google.com/a/lbl.gov/forum/#!topic/graphblas/CU2bTF1DV_8).