### PR TITLE
Include library in CMake configuration of MXM test

### DIFF
--- a/Test/MXM/CMakeLists.txt
+++ b/Test/MXM/CMakeLists.txt
@@ -75,6 +75,7 @@ link_directories ( ../../build )
 
 # include_directories ( /usr/local/include )
 include_directories ( ../../../GraphBLAS/Include )
+include_directories ( ../../../GraphBLAS/Source )
 include_directories ( ../../Include )
 
 #-------------------------------------------------------------------------------

--- a/Test/MXM/mxm_demo.c
+++ b/Test/MXM/mxm_demo.c
@@ -12,7 +12,7 @@
 //  mxm_demo
 
 #include "LAGraph.h"
-#include "../../../GraphBLAS/Source/GB_Global.h"
+#include "GB_Global.h"
 
 #define LAGRAPH_FREE_ALL    \
     (*ok) = false ;         \


### PR DESCRIPTION
I found an instance of a relative path in the includes:
```
#include "../../../GraphBLAS/Source/GB_Global.h"
```
This PR includes the GraphBLAS source directory in the `CMakeLists.txt` file.