### PR TITLE
Replace PLUS_TIMES with PLUS_FIRST semiring in pagerank2

### DIFF
--- a/Source/Algorithm/LAGraph_pagerank2.c
+++ b/Source/Algorithm/LAGraph_pagerank2.c
@@ -147,7 +147,7 @@ GrB_Info LAGraph_pagerank2 // alternative PageRank definition
             importance_vec,
             GrB_NULL,
             GrB_NULL,
-            GxB_PLUS_TIMES_FP64,
+            GxB_PLUS_FIRST_FP64,
             importance_vec,
             A,
             NULL


### PR DESCRIPTION
We assume a boolean adjacency matrix and therefore `times` is equal to `first`.
This change also makes it more clear, that its an unweighted pagerank version.

I couldn't find any performance benchmarks to run, but I am fairly certain, that `times` is slower than `first`.