### PR TITLE
Add Square Clustering (first draft)

### DIFF
--- a/experimental/algorithm/LAGr_SquareClustering.c
+++ b/experimental/algorithm/LAGr_SquareClustering.c
@@ -1,0 +1,169 @@
+//------------------------------------------------------------------------------
+// LAGr_SquareClustering: vertex square-clustering
+//------------------------------------------------------------------------------
+
+// LAGraph, (c) 2022 by The LAGraph Contributors, All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+// See additional acknowledgments in the LICENSE file,
+// or contact permission@sei.cmu.edu for the full terms.
+
+// Contributed by Erik Welch, NVIDIA.
+
+//------------------------------------------------------------------------------
+
+// TODO: summarize.
+
+// https://networkx.org/documentation/stable/reference/algorithms/generated/\
+//         networkx.algorithms.cluster.square_clustering.html
+// https://arxiv.org/pdf/2007.11111.pdf
+// https://arxiv.org/pdf/0710.0117v1.pdf
+
+//------------------------------------------------------------------------------
+
+#define LG_FREE_WORK                \
+{                                   \
+    GrB_free (&squares) ;           \
+    GrB_free (&denom) ;             \
+    GrB_free (&D) ;                 \
+    GrB_free (&P2) ;                \
+    GrB_free (&Q) ;                 \
+}
+
+#define LG_FREE_ALL                 \
+{                                   \
+    LG_FREE_WORK ;                  \
+    GrB_free (&r) ;                 \
+}
+
+#include <LAGraph.h>
+#include <LAGraphX.h>
+#include <LG_internal.h>  // from src/utility
+
+int LAGraph_SquareClustering
+(
+    // outputs:
+    GrB_Vector *square_clustering,
+    // inputs:
+    LAGraph_Graph G,
+    char *msg
+)
+{
+    LG_CLEAR_MSG ;
+
+    // The number of squares each node is part of
+    GrB_Vector squares = NULL ;
+
+    // Thought of as the total number of possible squares for each node
+    GrB_Vector denom = NULL ;
+
+    // Final result: the square coefficients for each node (squares / denom)
+    GrB_Vector r = NULL ;
+
+    // out_degrees assigned to diagonal matrix
+    GrB_Matrix D = NULL ;
+
+    // plus_pair(A @ A.T).new(mask=~D.S)
+    GrB_Matrix P2 = NULL ;
+
+    // Temporary workspace matrix (int64)
+    GrB_Matrix Q = NULL ;
+
+    GrB_Vector d_out = G->out_degree ;
+    GrB_Matrix A = G->A ;
+    GrB_Index n = 0 ;
+
+    //--------------------------------------------------------------------------
+    // check inputs
+    //--------------------------------------------------------------------------
+
+    LG_ASSERT (square_clustering != NULL, GrB_NULL_POINTER) ;
+    (*square_clustering) = NULL ;
+
+    LG_ASSERT_MSG (d_out != NULL,
+        LAGRAPH_NOT_CACHED, "G->out_degree is required") ;
+
+    LG_TRY (LAGraph_CheckGraph (G, msg)) ;
+
+    LG_ASSERT_MSG ((G->kind == LAGraph_ADJACENCY_UNDIRECTED ||
+       (G->kind == LAGraph_ADJACENCY_DIRECTED &&
+        G->is_symmetric_structure == LAGraph_TRUE)),
+        LAGRAPH_SYMMETRIC_STRUCTURE_REQUIRED,
+        "G->A must be known to be symmetric") ;
+
+    // # of nodes
+    GRB_TRY (GrB_Matrix_nrows (&n, A)) ;
+
+    // out_degrees as a diagonal matrix.  We use this twice:
+    // 1) as a mask to ignore the diagonal elements when computing `A @ A.T`
+    // 2) and to multiply each column of a matrix by the degrees.
+    GRB_TRY (GrB_Matrix_diag (&D, d_out, 0)) ;
+
+    // We'll use `P2 = plus_pair(A @ A.T).new(mask=~D.S)` throughout.
+    // We use ~D.S as a mask so P2 won't have values along the diagonal.
+    GRB_TRY (GrB_Matrix_new (&P2, GrB_INT64, n, n)) ;
+    GRB_TRY (GrB_mxm (P2, D, NULL, GxB_PLUS_PAIR_INT64, A, A, GrB_DESC_SCT1)) ;
+
+    // Now compute the number of squares (the numerator).  We cound squares
+    // based on https://arxiv.org/pdf/2007.11111.pdf (sigma_12, c_4).
+    //     Q = P2 * (P2 - 1)
+    //     squares = Q.reduce_rowwise() / 2  (and drop zeros)
+    GRB_TRY (GrB_Matrix_new (&Q, GrB_INT64, n, n)) ;
+    GRB_TRY (GrB_Matrix_apply_BinaryOp2nd_INT64 (Q, NULL, NULL, GrB_MINUS_INT64,
+        P2, 1, NULL)) ;
+    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Q, NULL, NULL, GrB_TIMES_INT64, Q,
+        P2, NULL)) ;
+    GRB_TRY (GrB_Vector_new (&squares, GrB_INT64, n)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (squares, NULL, NULL,
+        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
+    // Divide by 2, and use squares as value mask to drop zeros
+    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (squares, squares, NULL,
+        GrB_DIV_INT64, squares, 2, GrB_DESC_R));
+
+    // Denominator is thought of as total number of squares that could exist.
+    // We use the definition from https://arxiv.org/pdf/0710.0117v1.pdf.
+    // First three contributions will become negative in the final step.
+    //
+    // (1) Subtract 1 for each u and 1 for each w for all combos:
+    //     denom = d_out * (d_out - 1)
+    GRB_TRY (GrB_Vector_new (&denom, GrB_INT64, n)) ;
+    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (denom, NULL, NULL,
+        GrB_MINUS_INT64, d_out, 1, NULL)) ;
+    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_TIMES_INT64,
+        denom, d_out, NULL)) ;
+
+    // (2) Subtract the number of squares (will become negative, so add here):
+    //     denom = denom + squares
+    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_PLUS_INT64,
+        denom, squares, NULL)) ;
+
+    // (3) Subtract 1 for each edge where u-w or w-u are connected.
+    // In other words, triangles.  Use P2, since we already have it.
+    //     Q = first(P2 & A)
+    //     denom += Q.reduce_rowwise()
+    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Q, NULL, NULL, GrB_FIRST_INT64, P2,
+        A, NULL)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GrB_PLUS_INT64,
+        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
+
+    // The main contribution to the denominator:
+    //     degrees[u] + degrees[w] for each u-w combo.
+    // This is the only positive term.
+    // We subtract all other terms from this one, hence rminus.
+    //     Q = plus_pair(A @ P2.T).new(mask=A.S)
+    //     Q = any_times(Q @ D)
+    //     denom(rminus) = Q.reduce_rowwise()
+    GRB_TRY (GrB_mxm (Q, A, NULL, GxB_PLUS_PAIR_INT64, A, P2, GrB_DESC_RST1)) ;
+    GRB_TRY (GrB_mxm (Q, NULL, NULL, GxB_ANY_TIMES_INT64, Q, D, NULL)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GxB_RMINUS_INT64,
+        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
+
+    // Almost done!  Now compute the final result:
+    //     square_clustering = squares / denom
+    GRB_TRY (GrB_Vector_new (&r, GrB_FP64, n)) ;
+    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (r, NULL, NULL, GrB_DIV_FP64,
+        squares, denom, NULL)) ;
+
+    (*square_clustering) = r ;
+    LG_FREE_WORK ;
+    return (GrB_SUCCESS) ;
+}

--- a/experimental/algorithm/LAGraph_SquareClustering.c
+++ b/experimental/algorithm/LAGraph_SquareClustering.c
@@ -27,6 +27,7 @@
     GrB_free (&D) ;                 \
     GrB_free (&P2) ;                \
     GrB_free (&Q) ;                 \
+    GrB_free (&uw_degrees) ;        \
 }
 
 #define LG_FREE_ALL                 \
@@ -58,6 +59,9 @@ int LAGraph_SquareClustering
 
     // Final result: the square coefficients for each node (squares / denom)
     GrB_Vector r = NULL ;
+
+    // Used by pure GrB version; the largest factor of the denominator
+    GrB_Vector uw_degrees = NULL;
 
     // out_degrees assigned to diagonal matrix
     GrB_Matrix D = NULL ;
@@ -172,7 +176,6 @@ int LAGraph_SquareClustering
     GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GxB_RMINUS_INT64,
         GrB_PLUS_MONOID_INT64, Q, NULL)) ;
     #else
-    GrB_Vector uw_degrees = NULL;
     GRB_TRY (GrB_Vector_new (&uw_degrees, GrB_INT64, n)) ;
     GRB_TRY (GrB_Matrix_reduce_Monoid (uw_degrees, NULL, NULL,
         GrB_PLUS_MONOID_INT64, Q, NULL)) ;

--- a/experimental/algorithm/LAGraph_SquareClustering.c
+++ b/experimental/algorithm/LAGraph_SquareClustering.c
@@ -11,7 +11,7 @@
 
 //------------------------------------------------------------------------------
 
-// TODO: summarize.
+// TODO: summarize.  This calculates `P2 = A @ A.T`, which may be very large.
 
 // https://networkx.org/documentation/stable/reference/algorithms/generated/\
 //         networkx.algorithms.cluster.square_clustering.html
@@ -26,13 +26,13 @@
     GrB_free (&denom) ;             \
     GrB_free (&D) ;                 \
     GrB_free (&P2) ;                \
-    GrB_free (&Q) ;                 \
     GrB_free (&uw_degrees) ;        \
 }
 
 #define LG_FREE_ALL                 \
 {                                   \
     LG_FREE_WORK ;                  \
+    GrB_free (&Tri) ;               \
     GrB_free (&r) ;                 \
 }
 
@@ -61,16 +61,17 @@ int LAGraph_SquareClustering
     GrB_Vector r = NULL ;
 
     // Used by pure GrB version; the largest factor of the denominator
-    GrB_Vector uw_degrees = NULL;
+    GrB_Vector uw_degrees = NULL ;
 
     // out_degrees assigned to diagonal matrix
     GrB_Matrix D = NULL ;
 
-    // plus_pair(A @ A.T).new(mask=~D.S)
+    // P2 = plus_pair(A @ A.T).new(mask=~D.S)
+    // Then used as a temporary workspace matrix (int64)
     GrB_Matrix P2 = NULL ;
 
-    // Temporary workspace matrix (int64)
-    GrB_Matrix Q = NULL ;
+    // Triangles: first(P2 & A)
+    GrB_Matrix Tri = NULL ;
 
     GrB_Vector deg = G->out_degree ;
     GrB_Matrix A = G->A ;
@@ -119,22 +120,6 @@ int LAGraph_SquareClustering
     GRB_TRY (GrB_Matrix_new (&P2, GrB_INT64, n, n)) ;
     GRB_TRY (GrB_mxm (P2, D, NULL, LAGraph_plus_one_int64, A, A, GrB_DESC_SCT1)) ;
 
-    // Now compute the number of squares (the numerator).  We cound squares
-    // based on https://arxiv.org/pdf/2007.11111.pdf (sigma_12, c_4).
-    //     Q = P2 * (P2 - 1)
-    //     squares = Q.reduce_rowwise() / 2  (and drop zeros)
-    GRB_TRY (GrB_Matrix_new (&Q, GrB_INT64, n, n)) ;
-    GRB_TRY (GrB_Matrix_apply_BinaryOp2nd_INT64 (Q, NULL, NULL, GrB_MINUS_INT64,
-        P2, 1, NULL)) ;
-    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Q, NULL, NULL, GrB_TIMES_INT64, Q,
-        P2, NULL)) ;
-    GRB_TRY (GrB_Vector_new (&squares, GrB_INT64, n)) ;
-    GRB_TRY (GrB_Matrix_reduce_Monoid (squares, NULL, NULL,
-        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
-    // Divide by 2, and use squares as value mask to drop zeros
-    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (squares, squares, NULL,
-        GrB_DIV_INT64, squares, 2, GrB_DESC_R));
-
     // Denominator is thought of as total number of squares that could exist.
     // We use the definition from https://arxiv.org/pdf/0710.0117v1.pdf.
     // First three contributions will become negative in the final step.
@@ -147,38 +132,53 @@ int LAGraph_SquareClustering
     GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_TIMES_INT64,
         denom, deg, NULL)) ;
 
-    // (2) Subtract the number of squares (will become negative, so add here):
+    // (2) Subtract 1 for each edge where u-w or w-u are connected.
+    // In other words, triangles.  Use P2, since we already have it.
+    //     Tri = first(P2 & A)
+    //     denom += Tri.reduce_rowwise()
+    GRB_TRY (GrB_Matrix_new (&Tri, GrB_INT64, n, n)) ;
+    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Tri, NULL, NULL, GrB_FIRST_INT64, P2,
+        A, NULL)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GrB_PLUS_INT64,
+        GrB_PLUS_MONOID_INT64, Tri, NULL)) ;
+    GrB_free (&Tri) ;
+
+    // Now compute the number of squares (the numerator).  We count squares
+    // based on https://arxiv.org/pdf/2007.11111.pdf (sigma_12, c_4).
+    //     P2 *= P2 - 1
+    //     squares = P2.reduce_rowwise() / 2  (and drop zeros)
+    GRB_TRY (GrB_Matrix_apply_BinaryOp2nd_INT64 (P2, NULL, GrB_TIMES_INT64,
+        GrB_MINUS_INT64, P2, 1, NULL)) ;
+    GRB_TRY (GrB_Vector_new (&squares, GrB_INT64, n)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (squares, NULL, NULL,
+        GrB_PLUS_MONOID_INT64, P2, NULL)) ;
+    // Divide by 2, and use squares as value mask to drop zeros
+    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (squares, squares, NULL,
+        GrB_DIV_INT64, squares, 2, GrB_DESC_R)) ;
+
+    // (3) Subtract the number of squares (will become negative, so add here):
     //     denom = denom + squares
     GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_PLUS_INT64,
         denom, squares, NULL)) ;
-
-    // (3) Subtract 1 for each edge where u-w or w-u are connected.
-    // In other words, triangles.  Use P2, since we already have it.
-    //     Q = first(P2 & A)
-    //     denom += Q.reduce_rowwise()
-    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Q, NULL, NULL, GrB_FIRST_INT64, P2,
-        A, NULL)) ;
-    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GrB_PLUS_INT64,
-        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
 
     // The main contribution to the denominator:
     //     degrees[u] + degrees[w] for each u-w combo.
     // This is the only positive term.
     // We subtract all other terms from this one, hence rminus.
-    //     Q = plus_pair(A @ P2.T).new(mask=A.S)
-    //     Q = any_times(Q @ D)
-    //     denom(rminus) = Q.reduce_rowwise()
-    GRB_TRY (GrB_mxm (Q, A, NULL, LAGraph_plus_one_int64, A, P2,
+    //     P2 = plus_pair(A @ P2.T).new(mask=A.S)
+    //     P2 = any_times(P2 @ D)
+    //     denom(rminus) = P2.reduce_rowwise()
+    GRB_TRY (GrB_mxm (P2, A, NULL, LAGraph_plus_one_int64, A, P2,
         GrB_DESC_RST1)) ;
-    GRB_TRY (GrB_mxm (Q, NULL, NULL, GrB_PLUS_TIMES_SEMIRING_INT64, Q, D,
+    GRB_TRY (GrB_mxm (P2, NULL, NULL, GrB_PLUS_TIMES_SEMIRING_INT64, P2, D,
         NULL)) ;
     #if LAGRAPH_SUITESPARSE
     GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GxB_RMINUS_INT64,
-        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
+        GrB_PLUS_MONOID_INT64, P2, NULL)) ;
     #else
     GRB_TRY (GrB_Vector_new (&uw_degrees, GrB_INT64, n)) ;
     GRB_TRY (GrB_Matrix_reduce_Monoid (uw_degrees, NULL, NULL,
-        GrB_PLUS_MONOID_INT64, Q, NULL)) ;
+        GrB_PLUS_MONOID_INT64, P2, NULL)) ;
     GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL,
         GrB_MINUS_INT64, uw_degrees, denom, NULL)) ;
     #endif

--- a/experimental/test/test_SquareClustering.c
+++ b/experimental/test/test_SquareClustering.c
@@ -78,7 +78,7 @@ void test_SquareClustering (void)
     TEST_CHECK (nvals == 8) ;
 
     // OK (GrB_Vector_new(&soln, GrB_FP64, n)) ;
-    // OK (GrB_Vector_build_FP64(soln, soln_indices, soln_values, 2,
+    // OK (GrB_Vector_build_FP64(soln, soln_indices, soln_values, 8,
     //     GrB_PLUS_FP64)) ;
     double val;
     for (GrB_Index i = 0 ; i < 8 ; ++i)

--- a/experimental/test/test_SquareClustering.c
+++ b/experimental/test/test_SquareClustering.c
@@ -1,0 +1,101 @@
+//------------------------------------------------------------------------------
+// LAGraph/expirimental/test/test_SquareClustering.c: test cases for
+// square clustering
+// -----------------------------------------------------------------------------
+
+// LAGraph, (c) 2022 by The LAGraph Contributors, All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Contributed by Erik Welch, NVIDIA
+
+//------------------------------------------------------------------------------
+
+#include <stdio.h>
+#include <acutest.h>
+
+#include <LAGraphX.h>
+#include <LAGraph_test.h>
+#include "LG_Xtest.h"
+
+char msg [LAGRAPH_MSG_LEN] ;
+
+// Data from NetworkX, test_lind_square_clustering: https://github.com/networkx\
+//      /networkx/blob/main/networkx/algorithms/tests/test_cluster.py
+GrB_Index rows[19] = {1, 1, 1, 1, 2, 2, 3, 3, 6, 7, 6, 7, 7, 6, 6, 2, 2, 3, 3} ;
+GrB_Index cols[19] = {2, 3, 6, 7, 4, 5, 4, 5, 7, 8, 8, 9, 10, 11, 12, 13, 14,
+    15, 16} ;
+int64_t vals[19] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1} ;
+
+GrB_Index soln_indices[8] = {1, 2, 3, 4, 5, 6, 7, 8} ;
+double soln_values[8] = {
+    3.0 / 43.0,
+    3.0 / 17.0,
+    3.0 / 17.0,
+    1.0 / 3.0,
+    1.0 / 3.0,
+    1.0 / 27.0,
+    1.0 / 27.0,
+    1.0 / 5.0
+};
+
+//------------------------------------------------------------------------------
+// is_close: check whether two floats are close
+//------------------------------------------------------------------------------
+
+bool is_close (double a, double b)
+{
+    double abs_diff = fabs(a - b) ;
+    return abs_diff < 1e-6 ;
+}
+
+void test_SquareClustering (void)
+{
+    LAGraph_Init (msg) ;
+
+    GrB_Matrix A = NULL ;
+    LAGraph_Graph G = NULL ;
+
+    GrB_Index n = 17;
+    OK (GrB_Matrix_new (&A, GrB_INT64, n, n)) ;
+    OK (GrB_Matrix_build_INT64 (A, rows, cols, vals, 19, GrB_PLUS_INT64)) ;
+    // Symmetrize A
+    OK (GrB_Matrix_eWiseAdd_BinaryOp(A, NULL, NULL, GrB_FIRST_INT64, A, A,
+        GrB_DESC_T1));
+    OK (LAGraph_New (&G, &A, LAGraph_ADJACENCY_UNDIRECTED, msg)) ;
+    TEST_CHECK (A == NULL) ;
+
+    // check for self-edges
+    OK (LAGraph_Cached_NSelfEdges (G, msg)) ;
+    bool sanitize = (G->nself_edges != 0) ;
+
+    OK (LAGraph_Cached_OutDegree (G, msg)) ;
+
+    GrB_Vector c = NULL ;
+    OK (LAGraph_SquareClustering (&c, G, msg)) ;
+
+    GrB_Index nvals;
+    OK (GrB_Vector_nvals(&nvals, c)) ;
+    TEST_CHECK (nvals == 8) ;
+
+    // OK (GrB_Vector_new(&soln, GrB_FP64, n)) ;
+    // OK (GrB_Vector_build_FP64(soln, soln_indices, soln_values, 2,
+    //     GrB_PLUS_FP64)) ;
+    double val;
+    for (GrB_Index i = 0 ; i < 8 ; ++i)
+    {
+        GrB_Vector_extractElement_FP64(&val, c, soln_indices[i]) ;
+        TEST_CHECK (is_close(val, soln_values[i])) ;
+    }
+    // OK (GrB_free (&soln)) ;
+
+    OK (GrB_free (&c)) ;
+    OK (LAGraph_Delete (&G, msg)) ;
+
+    LAGraph_Finalize (msg) ;
+};
+
+TEST_LIST = {
+    {"SquareClustering", test_SquareClustering},
+    // {"SquareClustering_errors", test_errors},
+    {NULL, NULL}
+};

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -836,4 +836,13 @@ int LAGraph_FastGraphletTransform
     char *msg
 ) ;
 
+LAGRAPH_PUBLIC
+int LAGraph_SquareClustering
+(
+    // outputs:
+    GrB_Vector *square_clustering,
+    // inputs:
+    LAGraph_Graph G,
+    char *msg
+) ;
 #endif


### PR DESCRIPTION
I'm sure this is a little rough around the edges.  I wanted to see what's it's like adding a new algorithm to LAGraph.

This computes square clustering:
https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.cluster.square_clustering.html

It's based on the Python implementation here:
https://github.com/python-graphblas/graphblas-algorithms/blob/8de0be644df7daeb4d0b031db285705659a57e53/graphblas_algorithms/algorithms/cluster.py#L287-L323

Going from this Python to C code was super-easy.  I just copy/pasted the output from our C call recorder and reformatted a little:
https://github.com/python-graphblas/graphblas-algorithms/pull/14#issuecomment-1151418484

The hardest part was writing a test.  I used our recorder to help write C here too.  It should have more tests, such as against invalid input.

Counting the number of squares is from https://arxiv.org/pdf/2007.11111.pdf, which is part of experimental/algorithm/LAGraph_FastGraphletTransform.c.

Determining all the factors for the denominator was actually kind of tricky for me.  We use equation 2 from this paper for the denominator:
https://arxiv.org/pdf/0710.0117v1.pdf

To my knowledge, square clustering hasn't been implemented in GraphBLAS before.

This is untested for directed graphs and graphs with self-edges.  It is also not benchmarked or optimized against benchmarking.  Since we assume symmetric structure, we have some freedom when to transpose some inputs.

This uses a few GxB operators:
- GxB_PLUS_PAIR_INT64 (is there a GrB equivalent for this yet?)
- GxB_ANY_TIMES_INT64 (monoid doesn't matter, so could be replaced)
- GxB_RMINUS_INT64 (by using RMINUS, we avoid creating another vector)

Happy to accept any feedback.  Also fine if this sits here a while (since, you know, we're supposed to be writing documentation and getting ready for 1.0 instead of writing new algorithms!).