### PR TITLE
Summarize square clustering (and improve a term)

### DIFF
--- a/experimental/algorithm/LAGraph_SquareClustering.c
+++ b/experimental/algorithm/LAGraph_SquareClustering.c
@@ -11,12 +11,63 @@
 
 //------------------------------------------------------------------------------
 
-// TODO: summarize.  This calculates `P2 = A @ A.T`, which may be very large.
+// Compute the square clustering coefficient for each node of an undirected
+// graph, which is the fraction of possible squares that exist at each node.
+// It is a clustering coefficient suitable for bipartite graphs and is fully
+// described here:
+//      https://arxiv.org/pdf/0710.0117v1.pdf
+// which uses a different denominator than the original definition:
+//      https://arxiv.org/pdf/cond-mat/0504241.pdf
+// Furthermore, we count squares based on
+//      https://arxiv.org/pdf/2007.11111.pdf (sigma_12, c_4)
+// which is implemented in LAGraph_FastGraphletTransform.c (thanks Tim Davis
+// for mentioning this to me!).
 
-// https://networkx.org/documentation/stable/reference/algorithms/generated/\
-//         networkx.algorithms.cluster.square_clustering.html
-// https://arxiv.org/pdf/2007.11111.pdf
-// https://arxiv.org/pdf/0710.0117v1.pdf
+// The NetworkX implementation of square clustering was used heavily during
+// development.  I used it to determine the contributions to the denominator
+// and to verify correctness (including on larger graphs).
+//      https://networkx.org/documentation/stable/reference/algorithms/\
+//      generated/networkx.algorithms.cluster.square_clustering.html
+
+// Pseudocode (doesn't show dropping 0s in the final result):
+//
+//    P2(~degrees.diag().S) = plus_pair(A @ A.T)
+//    tri = first(P2 & A).reduce_rowwise()
+//    squares = (P2 * (P2 - 1)).reduce_rowwise() / 2
+//    uw_count = degrees * (degrees - 1)
+//    uw_degrees = plus_times(A @ degrees) * (degrees - 1)
+//    square_clustering = squares / (uw_degrees - uw_count - tri - squares)
+
+// The coefficient as described in https://arxiv.org/pdf/0710.0117v1.pdf
+// where m and n are different neighbors of node i.
+// Note that summations over mn are implied in the numerator and denominator:
+//
+//    C_{4,mn}(i) = q_imn / ((k_m - eta_imn) + (k_n - eta_imn) + q_imn)
+//    q_imn = # of common neighbors between m and n (i.e., squares)
+//    k_m = number of neighbors of m (i.e., degrees[m])
+//    eta_imn = 1 + q_imn + theta_mn
+//    theta_mn = 1 if m and n are connected, otherwise 0 (i.e., triangles)
+
+// Here are the corresponding terms between the equation and pseudocode:
+//    theta_mn          <--> tri
+//    q_imn             <--> squares
+//    eta_imn = 1 + ... <--> uw_count
+//    k_m               <--> uw_degrees
+
+// I first implemented this in the Python library graphblas-algorithms
+//      https://github.com/python-graphblas/graphblas-algorithms/\
+//      blob/main/graphblas_algorithms/algorithms/cluster.py
+// and I copy/pasted C code generated from the Recorder in Python-graphblas
+//      https://github.com/python-graphblas/python-graphblas
+
+// This implementation requires that `out_degree` property is already cached.
+// 0 values are omitted from the result (i.e., missing values <--> zero).
+// Also, it computes `P2 = A @ A.T`, which may be very large.  We could modify
+// the algorithm to compute coefficients for a subset of nodes, which would
+// allow expert users to compute in batches.  Also, since this algorithm only
+// operates on undirected or symmetric graphs, we only need to compute the
+// upper (or lower) triangle of P2, which should reduce memory by about half.
+// However, this is not easy to do, and would complicate the implementation.
 
 //------------------------------------------------------------------------------
 
@@ -24,15 +75,13 @@
 {                                   \
     GrB_free (&squares) ;           \
     GrB_free (&denom) ;             \
-    GrB_free (&D) ;                 \
-    GrB_free (&P2) ;                \
-    GrB_free (&uw_degrees) ;        \
 }
 
 #define LG_FREE_ALL                 \
 {                                   \
     LG_FREE_WORK ;                  \
-    GrB_free (&Tri) ;               \
+    GrB_free (&D) ;                 \
+    GrB_free (&P2) ;                \
     GrB_free (&r) ;                 \
 }
 
@@ -57,21 +106,19 @@ int LAGraph_SquareClustering
     // Thought of as the total number of possible squares for each node
     GrB_Vector denom = NULL ;
 
+    // Negative contributions to the denominator
+    GrB_Vector neg_denom = NULL ;
+
     // Final result: the square coefficients for each node (squares / denom)
     GrB_Vector r = NULL ;
 
-    // Used by pure GrB version; the largest factor of the denominator
-    GrB_Vector uw_degrees = NULL ;
-
     // out_degrees assigned to diagonal matrix
+    // Then used as triangles: first(P2 & A)
     GrB_Matrix D = NULL ;
 
     // P2 = plus_pair(A @ A.T).new(mask=~D.S)
     // Then used as a temporary workspace matrix (int64)
     GrB_Matrix P2 = NULL ;
-
-    // Triangles: first(P2 & A)
-    GrB_Matrix Tri = NULL ;
 
     GrB_Vector deg = G->out_degree ;
     GrB_Matrix A = G->A ;
@@ -98,9 +145,7 @@ int LAGraph_SquareClustering
     // # of nodes
     GRB_TRY (GrB_Matrix_nrows (&n, A)) ;
 
-    // out_degrees as a diagonal matrix.  We use this twice:
-    // 1) as a mask to ignore the diagonal elements when computing `A @ A.T`
-    // 2) and to multiply each column of a matrix by the degrees.
+    // out_degrees as a diagonal matrix.
     #if LAGRAPH_SUITESPARSE
         #if GxB_IMPLEMENTATION >= GxB_VERSION (7,0,0)
         // SuiteSparse 7.x and later:
@@ -115,34 +160,28 @@ int LAGraph_SquareClustering
     GRB_TRY (GrB_Matrix_diag(&D, deg, 0)) ;
     #endif
 
-    // We'll use `P2 = plus_pair(A @ A.T).new(mask=~D.S)` throughout.
     // We use ~D.S as a mask so P2 won't have values along the diagonal.
+    //    P2(~D.S) = plus_pair(A @ A.T)
     GRB_TRY (GrB_Matrix_new (&P2, GrB_INT64, n, n)) ;
     GRB_TRY (GrB_mxm (P2, D, NULL, LAGraph_plus_one_int64, A, A, GrB_DESC_SCT1)) ;
 
     // Denominator is thought of as total number of squares that could exist.
-    // We use the definition from https://arxiv.org/pdf/0710.0117v1.pdf.
-    // First three contributions will become negative in the final step.
+    // It has four terms (indicated below), and we use the definition from:
+    //      https://arxiv.org/pdf/0710.0117v1.pdf.
     //
-    // (1) Subtract 1 for each u and 1 for each w for all combos:
-    //     denom = deg * (deg - 1)
-    GRB_TRY (GrB_Vector_new (&denom, GrB_INT64, n)) ;
-    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (denom, NULL, NULL,
-        GrB_MINUS_INT64, deg, 1, NULL)) ;
-    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_TIMES_INT64,
-        denom, deg, NULL)) ;
-
-    // (2) Subtract 1 for each edge where u-w or w-u are connected.
+    // (1) tri = first(P2 & A).reduce_rowwise()
+    // Subtract 1 for each edge where u-w or w-u are connected.
     // In other words, triangles.  Use P2, since we already have it.
-    //     Tri = first(P2 & A)
-    //     denom += Tri.reduce_rowwise()
-    GRB_TRY (GrB_Matrix_new (&Tri, GrB_INT64, n, n)) ;
-    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (Tri, NULL, NULL, GrB_FIRST_INT64, P2,
+    //     D = first(P2 & A)
+    //     neg_denom = D.reduce_rowwise()
+    GRB_TRY (GrB_Matrix_eWiseMult_BinaryOp (D, NULL, NULL, GrB_FIRST_INT64, P2,
         A, NULL)) ;
-    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GrB_PLUS_INT64,
-        GrB_PLUS_MONOID_INT64, Tri, NULL)) ;
-    GrB_free (&Tri) ;
+    GRB_TRY (GrB_Vector_new (&neg_denom, GrB_INT64, n)) ;
+    GRB_TRY (GrB_Matrix_reduce_Monoid (neg_denom, NULL, NULL,
+        GrB_PLUS_MONOID_INT64, D, NULL)) ;
+    GrB_free (&D) ;
 
+    // squares = (P2 * (P2 - 1)).reduce_rowwise() / 2
     // Now compute the number of squares (the numerator).  We count squares
     // based on https://arxiv.org/pdf/2007.11111.pdf (sigma_12, c_4).
     //     P2 *= P2 - 1
@@ -152,39 +191,37 @@ int LAGraph_SquareClustering
     GRB_TRY (GrB_Vector_new (&squares, GrB_INT64, n)) ;
     GRB_TRY (GrB_Matrix_reduce_Monoid (squares, NULL, NULL,
         GrB_PLUS_MONOID_INT64, P2, NULL)) ;
+    GrB_free (&P2) ;
     // Divide by 2, and use squares as value mask to drop zeros
     GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64 (squares, squares, NULL,
         GrB_DIV_INT64, squares, 2, GrB_DESC_R)) ;
 
-    // (3) Subtract the number of squares (will become negative, so add here):
-    //     denom = denom + squares
-    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL, GrB_PLUS_INT64,
-        denom, squares, NULL)) ;
+    // (2) uw_count = degrees * (degrees - 1).
+    // Subtract 1 for each u and 1 for each w for all combos.
+    //    denom(squares.S) = degrees - 1
+    GRB_TRY (GrB_Vector_new (&denom, GrB_INT64, n)) ;
+    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_INT64(denom, squares, NULL,
+        GrB_MINUS_INT64, deg, 1, GrB_DESC_S)) ;
+    // neg_denom += degrees * (degrees - 1)
+    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp(neg_denom, NULL, GrB_PLUS_INT64,
+        GrB_TIMES_INT64, deg, denom, NULL)) ;
 
-    // The main contribution to the denominator:
-    //     degrees[u] + degrees[w] for each u-w combo.
-    // This is the only positive term.
-    // We subtract all other terms from this one, hence rminus.
-    //     P2 = plus_pair(A @ P2.T).new(mask=A.S)
-    //     P2 = any_times(P2 @ D)
-    //     denom(rminus) = P2.reduce_rowwise()
-    GRB_TRY (GrB_mxm (P2, A, NULL, LAGraph_plus_one_int64, A, P2,
-        GrB_DESC_RST1)) ;
-    GRB_TRY (GrB_mxm (P2, NULL, NULL, GrB_PLUS_TIMES_SEMIRING_INT64, P2, D,
-        NULL)) ;
-    #if LAGRAPH_SUITESPARSE
-    GRB_TRY (GrB_Matrix_reduce_Monoid (denom, NULL, GxB_RMINUS_INT64,
-        GrB_PLUS_MONOID_INT64, P2, NULL)) ;
-    #else
-    GRB_TRY (GrB_Vector_new (&uw_degrees, GrB_INT64, n)) ;
-    GRB_TRY (GrB_Matrix_reduce_Monoid (uw_degrees, NULL, NULL,
-        GrB_PLUS_MONOID_INT64, P2, NULL)) ;
-    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (denom, NULL, NULL,
-        GrB_MINUS_INT64, uw_degrees, denom, NULL)) ;
-    #endif
+    // (3) uw_degrees = plus_times(A @ degrees) * (degrees - 1).
+    // The main contribution to (and only positive term of) the denominator:
+    // degrees[u] + degrees[w] for each u-w combo.
+    // Recall that `denom = degrees - 1` from above.
+    //    denom(denom.S) *= plus_times(A @ deg)
+    GRB_TRY (GrB_mxv(denom, denom, GrB_TIMES_INT64,
+        GrB_PLUS_TIMES_SEMIRING_INT64, A, deg, GrB_DESC_S)) ;
 
+    // (4) squares.  Subtract the number of squares
+    //    denom -= neg_denom + squares
+    GRB_TRY (GrB_Vector_eWiseMult_BinaryOp(denom, NULL, GrB_MINUS_INT64,
+        GrB_PLUS_INT64, neg_denom, squares, NULL)) ;
+
+    // square_clustering = squares / (uw_degrees - uw_count - tri - squares)
     // Almost done!  Now compute the final result:
-    //     square_clustering = squares / denom
+    //    square_clustering = r = squares / denom
     GRB_TRY (GrB_Vector_new (&r, GrB_FP64, n)) ;
     GRB_TRY (GrB_Vector_eWiseMult_BinaryOp (r, NULL, NULL, GrB_DIV_FP64,
         squares, denom, NULL)) ;


### PR DESCRIPTION
This adds a more detailed discussion for square clustering and continues #130.
I added pseudocode to illustrate the algorithm (but doesn't quite show _everything_):
```
    P2(~degrees.diag().S) = plus_pair(A @ A.T)
    tri = first(P2 & A).reduce_rowwise()
    squares = (P2 * (P2 - 1)).reduce_rowwise() / 2
    uw_count = degrees * (degrees - 1)
    uw_degrees = plus_times(A @ degrees) * (degrees - 1)
    square_clustering = squares / (uw_degrees - uw_count - tri - squares)
```
This PR also improves how we calculate `uw_degrees`.  Previously, we used matrix multiplies:
```
    P2(A.S) = plus_pair(A @ P2.T)
    P2 = any_times(P2 @ degrees.diag())
    uw_degrees = P2.reduce_rowwise()
```
The new expression, `uw_degrees = plus_times(A @ degrees) * (degrees - 1)`, is _much_ more efficient.  Figuring out a good expression for this term was not obvious to me, but using `plus_pair` previously was a hint that maybe a better expression existed.

Now, virtually all the time is spent computing the number of squares.  Calculating the denominator is negligible.  Interestingly, calculating `P2 * (P2 - 1)` via `P2(binary.times) = P2 - 1` is sometimes the slowest calculation.

I think this is pretty fast.  However, the tradeoff is memory usage to calculate and store `P2 = A @ A`.  A possible enhancement would be to compute square clustering for a subset of nodes, which would allow advanced users to compute in batches to use less memory.  Such a design paradigm does not yet exist in LAGraph.

CC @DrTimothyAldenDavis and @szarnyasg who reviewed the previous square clustering PR.