### PR TITLE
Move use of NVIDIA libraries into an option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,15 @@ find_package (GraphBLAS REQUIRED MODULE)
 include ( GNUInstallDirs )
 
 #-------------------------------------------------------------------------------
+# Provide user settable options.
+#-------------------------------------------------------------------------------
+
+option(ENABLE_NVIDIA "Enable use of NVIDIA libraries" FALSE)
+if(ENABLE_NVIDIA)
+    add_compile_definitions(LAGRAPH_USE_NVIDIA)
+endif()
+
+#-------------------------------------------------------------------------------
 # determine what user threading model to use
 #-------------------------------------------------------------------------------
 
@@ -268,7 +277,8 @@ add_subdirectory(src)
 add_subdirectory(experimental)
 
 #-------------------------------------------------------------------------------
-# to install use "sudo make install"
+# to install use "sudo make install" or run cmake with -DCMAKE_INSTALL_PREFIX
+# to redirect the base installation directory.
 #-------------------------------------------------------------------------------
 
 # only install the dynamic  library

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 # and /home/me/mystuff/include), do not use this Makefile.  Instead, do:
 #
 #       cd build
-#       cmake -DCMAKE_INSTALL_PREFIX="/home/me/mystuff" ..
+#       cmake .. -DCMAKE_INSTALL_PREFIX="/home/me/mystuff"
 #       make
 #       make install
 #
@@ -41,6 +41,10 @@
 # To uninstall:
 #
 #       make uninstall
+#
+# To enable using NVIDIA's memory management libraries in the benchmarks:
+#
+#       make CMAKE_OPTIONS="-DENABLE_NVIDIA=TRUE"
 #
 # To compile and run test coverage: use "make cov".  Next, open your browser to
 # your local file, LAGraph/build/test_coverage/index.html.  Be sure to do "make

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -12,7 +12,20 @@
 include_directories ( ${CMAKE_SOURCE_DIR}/src/test/include
     ${CMAKE_SOURCE_DIR}/src/algorithm )
 
-file( GLOB DEMO_SOURCES LIST_DIRECTORIES false *_demo.c )
+set(DEMO_SOURCES
+    bc_demo.c
+    bfs_demo.c
+    cc_demo.c
+    gappagerank_demo.c
+    mtx2bin_demo.c
+    ss2_demo.c
+    sssp_demo.c
+    tc_demo.c)
+
+if(ENABLE_NVIDIA)
+    list(APPEND DEMO_SOURCES tc_gpu_demo.c)
+endif()
+
 foreach( demosourcefile ${DEMO_SOURCES} )
     get_filename_component(justname ${demosourcefile} NAME)
     string( REPLACE ".c" "" demoname ${justname} )

--- a/src/benchmark/LAGraph_demo.h
+++ b/src/benchmark/LAGraph_demo.h
@@ -1107,16 +1107,16 @@ static inline int demo_init (bool burble)
     mallopt (M_TOP_PAD, 16*1024*1024) ; // increase padding to speedup malloc
     #endif
 
-#if 0
-    // just use the CPU
-    LAGRAPH_TRY (LAGraph_Init (NULL)) ;
-#else
+#if defined(LAGRAPH_USE_NVIDIA)
     // use the GPU
     // rmm_wrap_initialize (rmm_wrap_managed, INT32_MAX, INT64_MAX) ;
     rmm_wrap_initialize (rmm_wrap_managed, 256 * 1000000L, 256 * 1000000000L) ;
     LAGRAPH_TRY (LAGr_Init (GxB_NONBLOCKING_GPU, rmm_wrap_malloc,
         rmm_wrap_calloc, rmm_wrap_realloc, rmm_wrap_free, NULL)) ;
     GxB_set (GxB_GPU_CONTROL, GxB_GPU_ALWAYS) ;
+#else
+    // just use the CPU
+    LAGRAPH_TRY (LAGraph_Init (NULL)) ;
 #endif
 
     #if LAGRAPH_SUITESPARSE


### PR DESCRIPTION
Just makes life a tad more sane for the rest of us.

And cmake "style" is cmake .. (rest of options).  Historical reasons, I'm sure.