### PR TITLE
Build against latest SuiteSparse:GraphBLAS stable version in CI, fix MacOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.0.1, conda_grb_package_hash: h27087fc}
          - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc}
+         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -48,8 +48,8 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.0.1, conda_grb_package_hash: h3f3baac}
          - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4}
+         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         name: test_coverage
         path: build/test_coverage/
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         config:
@@ -55,7 +55,8 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew install libomp
+        brew extract --version=14.0.6 libomp homebrew/cask
+        brew install libomp@14.0.6
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries
@@ -68,9 +69,7 @@ jobs:
         export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
         export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.dylib
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
-        mv CMakeLists.txt CMakeLists2.txt
-        echo 'include_directories("/usr/local/opt/libomp/include")' > CMakeLists1.txt
-        cat CMakeLists1.txt CMakeLists2.txt > CMakeLists.txt
+        echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
         CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
         JOBS=2 make


### PR DESCRIPTION
This PR implements three changes:

* It adds SuiteSparse:GraphBLAS v7.3.0 to the CI build.
* The CI build for v7.0.1 is removed.
* For the MacOS build, it pins the `libomp` dependency's version to v14. With v15 (which is installed by default since September), the following error occurs:
    ```console
    Undefined symbols for architecture x86_64:
      "_omp_get_max_threads", referenced from:
          _LAGraph_FastGraphletTransform in LAGraph_FastGraphletTransform.c.o
    ld: symbol(s) not found for architecture x86_64
    ```