### PR TITLE
Include SuiteSparse:GraphBLAS v7.4.1 in CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc}
-         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
+         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -20,8 +21,13 @@ jobs:
       run: |
         mkdir graphblas-binaries
         cd graphblas-binaries
-        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/linux-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.bz2
-        tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.bz2
+        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/linux-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+        if [ ${{ matrix.config.conda_extension }} == "tar.bz2" ]; then
+          tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+        else
+          unzip graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+          tar xf pkg-graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.zst
+        fi
         cd ..
     - name: Build project
       run: |
@@ -33,7 +39,7 @@ jobs:
         make test_coverage
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: matrix.config.grb_version == '7.1.0' && github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      if: matrix.config.grb_version == '7.4.1' && github.event_name == 'push' && github.ref == 'refs/heads/stable'
       with:
         branch: gh-pages
         folder: build/test_coverage/
@@ -48,8 +54,9 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4}
-         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4, conda_extension: tar.bz2}
+         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a, conda_extension: tar.bz2}
+         - {grb_version: 7.4.1, conda_grb_package_hash: ha894c9a, conda_extension: conda}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -61,8 +68,13 @@ jobs:
       run: |
         mkdir graphblas-binaries
         cd graphblas-binaries
-        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/osx-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.bz2
-        tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.bz2
+        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/osx-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+        if [ ${{ matrix.config.conda_extension }} == "tar.bz2" ]; then
+          tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+        else
+          unzip graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
+          tar xf pkg-graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.zst
+        fi
         cd ..
     - name: Build project
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         config:


### PR DESCRIPTION
This PR implements three key changes:
* It adds SuiteSparse:GraphBLAS v7.4.1 in CI tests
* It introduces support for decompressing Conda packages using the new [Conda file format](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html#conda-file-format)
* It bumps the Linux CI worker's version from Ubuntu 20.04 to 22.04.