### PR TITLE
Test VANILLA builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
         export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.so
         cd build
-        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.vanilla }}
+        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
         JOBS=2 make
         make test_coverage
     - name: Deploy
@@ -85,6 +85,6 @@ jobs:
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
         echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
-        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.vanilla }}
+        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
         JOBS=2 make
         make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,10 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
-         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
+         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 0}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -34,7 +35,7 @@ jobs:
         export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
         export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.so
         cd build
-        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
+        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.vanilla }}
         JOBS=2 make
         make test_coverage
     - name: Deploy
@@ -54,9 +55,10 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4, conda_extension: tar.bz2}
-         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a, conda_extension: tar.bz2}
-         - {grb_version: 7.4.1, conda_grb_package_hash: ha894c9a, conda_extension: conda}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
+         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 0}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -83,6 +85,6 @@ jobs:
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
         echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
-        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
+        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.vanilla }}
         JOBS=2 make
         make test


### PR DESCRIPTION
# General

This PR resolves #156 and adds builds using `LAGRAPH_VANILLA=1` (i.e. turning on vanilla builds) to the CI.

# Details

The vanilla builds aren't tested with several versions of GraphBLAS like non-vanilla builds, they use the latest one (currently 7.4.1). If you'd like me to add more configurations for vanilla builds, I can, just let me know!