### PR TITLE
CI: Only run with current latest SS:GrB from Conda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,8 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
-         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 0}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 1}
+         - {grb_version: 7.4.3, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 0}
+         - {grb_version: 7.4.3, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -56,10 +54,8 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
-         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2, vanilla: 0}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 0}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda,   vanilla: 1}
+         - {grb_version: 7.4.3, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 0}
+         - {grb_version: 7.4.3, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0


### PR DESCRIPTION
The CI suddenly started failing:
https://github.com/GraphBLAS/LAGraph/actions/runs/4364180278/jobs/7631183444

This was due to the link:
<https://anaconda.org/conda-forge/graphblas/7.1.0/download/osx-64/graphblas-7.1.0-h27087fc_0.tar.bz2>
being broken.

Apparently, the hash changed from `h27087fc` to `h7881ed4` which is quite an unusual move from a package repository.
<https://anaconda.org/conda-forge/graphblas/7.1.0/download/osx-64/graphblas-7.1.0-h7881ed4_0.tar.bz2>

It is entirely possible that I'm misunderstanding something regarding the Conda Forge naming convention. Still, I'd like to minimize the chance of the CI breaking between commits, so I removed the older SuiteSparse:GraphBLAS versions, v7.1.x and v7.3.x, from the build matrix. I also updated the v7.4.x line to v7.4.3.