### PR TITLE
PageRankGX: Remove tolerance argument

### DIFF
--- a/experimental/algorithm/LAGr_PageRankGX.c
+++ b/experimental/algorithm/LAGr_PageRankGX.c
@@ -56,7 +56,6 @@ int LAGr_PageRankGX
     // input:
     const LAGraph_Graph G,  // input graph
     float damping,          // damping factor (typically 0.85)
-    float tol,              // stopping tolerance (typically 1e-4)
     int itermax,            // maximum number of iterations (typically 100)
     char *msg
 )
@@ -99,7 +98,6 @@ int LAGr_PageRankGX
 
     const float scaled_damping = (1 - damping) / n ;
     const float teleport = scaled_damping ; // teleport = (1 - damping) / n
-    float rdiff = 1 ;       // first iteration is always done
 
     // Determine vector of non-sink vertices:
     // These vertices are the ones which have outgoing edges. In subsequent
@@ -136,7 +134,7 @@ int LAGr_PageRankGX
 
     printf("running pagerank for a maximum of %d iterations", itermax);
 
-    for ((*iters) = 0 ; (*iters) < itermax && rdiff > tol ; (*iters)++)
+    for ((*iters) = 0 ; (*iters) < itermax ; (*iters)++)
     {
         // swap t and r ; now t is the old score
         GrB_Vector temp = t ; t = r ; r = temp ;
@@ -168,8 +166,6 @@ int LAGr_PageRankGX
         GRB_TRY (GrB_assign (t, NULL, GrB_MINUS_FP32, r, GrB_ALL, n, NULL)) ;
         // t = abs (t)
         GRB_TRY (GrB_apply (t, NULL, NULL, GrB_ABS_FP32, t, NULL)) ;
-        // rdiff = sum (t)
-        GRB_TRY (GrB_reduce (&rdiff, NULL, GrB_PLUS_MONOID_FP32, t, NULL)) ;
     }
 
     //--------------------------------------------------------------------------

--- a/experimental/test/test_PageRankGX.c
+++ b/experimental/test/test_PageRankGX.c
@@ -223,7 +223,7 @@ void test_ranker(void)
     OK (GrB_free (&centrality)) ;
 
     // compute its pagerank using the LDBC Graphalytics method
-    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 1e-4, 100, msg)) ;
+    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 100, msg)) ;
 
     // compare with MATLAB: cmatlab = centrality (G, 'pagerank')
     err = difference (centrality, karate_rank) ;
@@ -266,7 +266,7 @@ void test_ranker(void)
     OK (GrB_free (&centrality)) ;
 
     // compute its pagerank using the LDBC Graphalytics method
-    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 1e-4, 100, msg)) ;
+    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 100, msg)) ;
 
     // compare with MATLAB: cmatlab = centrality (G, 'pagerank')
     err = difference (centrality, west0067_rank) ;
@@ -310,7 +310,7 @@ void test_ranker(void)
     OK (GrB_free (&centrality)) ;
 
     // compute its pagerank using the LDBC Graphalytics method
-    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 1e-4, 100, msg)) ;
+    OK (LAGr_PageRankGX (&centrality, &niters, G, 0.85, 100, msg)) ;
 
     // compare with MATLAB: cmatlab = centrality (G, 'pagerank')
     err = difference (centrality, ldbc_directed_example_rank) ;

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -666,7 +666,6 @@ int LAGraph_cdlp
  * @param[out] iters        number of iterations taken.
  * @param[in] G             input graph.
  * @param[in] damping       damping factor (typically 0.85).
- * @param[in] tol           stopping tolerance (typically 1e-4).
  * @param[in] itermax       maximum number of iterations (typically 100).
  * @param[in,out] msg       any error messages.
  *
@@ -687,7 +686,6 @@ int LAGr_PageRankGX
     // input:
     const LAGraph_Graph G,
     float damping,
-    float tol,
     int itermax,
     char *msg
 ) ;


### PR DESCRIPTION
The PageRank algorithms in LAGraph use a tolerance parameter which uses an absolute value (according to the comment, typically selected to be 10e-4) to terminate the execution early. The [PageRank algorithm in Graphalytics](https://arxiv.org/pdf/2011.15028v5.pdf#page=14) (`PageRankGX`) does not have such a stopping condition – algorithms must run a fixed number of iterations. Therefore, calculating the `rdiff` is not necessary.

(Note: Graphalytics uses a _relative tolerance_ of 0.01% for comparing results against the reference output, but this should not be taken into consideration during the execution of the algorithm.)
