### PR TITLE
Added type handling to LAGraph_Coarsen_Matching

### DIFF
--- a/experimental/algorithm/LAGraph_MaximalMatching.c
+++ b/experimental/algorithm/LAGraph_MaximalMatching.c
@@ -70,6 +70,8 @@ appear in the matching.
     GrB_free(&result) ;                     \
 }                                           \
 
+#define MAX_FAILURES 50
+
 int LAGraph_MaximalMatching
 (
     // outputs:
@@ -91,8 +93,6 @@ int LAGraph_MaximalMatching
     if (E == NULL) {
         return GrB_NULL_POINTER ;
     }
-
-    const GrB_Index MAX_FAILURES = 50 ;
 
     GrB_Matrix E_t = NULL ;                     // E transpose. Maybe it's better to use 'A' descriptor instead of storing this explicitly?
     GrB_Vector score = NULL ;                   // score for each edge. Computed according to matching_type

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -25,9 +25,9 @@ int main(int argc, char **argv)
 
     GrB_Matrix A = G->A ;
 
-    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 0, 1, 2, 42, msg)) ;
+    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 1, 1, 1, 67, msg)) ;
     LAGRAPH_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
-    LAGRAPH_TRY (LAGraph_Vector_Print (mappings[1], LAGraph_COMPLETE, stdout, msg)) ;
+    // LAGRAPH_TRY (LAGraph_Vector_Print (mappings[0], LAGraph_COMPLETE, stdout, msg)) ;
     /*
     char msg[1024] ;
     LAGraph_Init (msg) ;

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
 
     LAGRAPH_TRY (LAGraph_Random_Init (msg)) ;
     LAGRAPH_TRY (readproblem (&G, NULL,
-        true, true, false, GrB_FP64, false, argc, argv)) ;
+        true, true, false, GrB_INT8, false, argc, argv)) ;
     
     GrB_Vector *mappings ;
     GrB_Matrix coarsened ;

--- a/experimental/benchmark/matching_demo.c
+++ b/experimental/benchmark/matching_demo.c
@@ -17,7 +17,7 @@
 Usage:
 Option 1: Run for performance
 ./matching_demo <matrix_name> <matching_type>
-matrix_name: either the name of the .mtx file or empty for stdin
+matrix_name: either the name of the .mtx file or "stdin" for stdin
 matching_type: 0, 1, 2 for random matching, heavy edge matching, and light edge matching respectively
 NOTE: This is the typical scenario that all other benchmark codes are used for
 
@@ -68,24 +68,31 @@ int main (int argc, char** argv)
     GrB_Vector best_matching = NULL ;
     GrB_Vector use_weights = NULL ;
 
-    bool burble = false ; 
+    bool burble = true ; 
     demo_init (burble) ;
 
     //--------------------------------------------------------------------------
     // read in the graph
     //--------------------------------------------------------------------------
-    char *matrix_name = (argc > 1) ? argv [1] : "stdin" ;
-    int force_stdin = 0 ;
-
-    if (argc > 1) {
-        // -q option as the matrix name means to run the quality tests
-        force_stdin = ( strcmp (argv [1], "-q") == 0 ) ;
-
-        if (force_stdin) {
-            // mark that I am not running performance benchmarks, but printing data for my external tests
-            test_performance = false ;
-        }
+    if (argc <= 2) {
+        printf ("Invalid usage, read comments\n") ;
+        return 0 ;
     }
+
+    int quality = 0 ;
+    int force_stdin = 0 ;
+    char *matrix_name = argv [1] ;
+    // -q option as the matrix name means to run the quality tests
+    quality = ( strcmp (matrix_name, "-q") == 0 ) ;
+    force_stdin = ( strcmp (matrix_name, "stdin") == 0 );
+
+    force_stdin = force_stdin || quality ;
+
+    if (quality) {
+        // mark that I am not running performance benchmarks, but printing data for my external tests
+        test_performance = false ;
+    }
+
     LAGRAPH_TRY (LAGraph_Random_Init (msg)) ;
     LAGRAPH_TRY (readproblem (&G, NULL,
         true, true, false, GrB_FP64, false, force_stdin ? 1 : argc, argv)) ;
@@ -109,8 +116,12 @@ int main (int argc, char** argv)
         //--------------------------------------------------------------------------
         // Printing E matrix, best result from ntrial runs for my own, external tests for quality (not performance)
         //--------------------------------------------------------------------------
-        int ntrials = atoi(argv [3]) ;
-        int matching_type = atoi(argv [2]) ;
+        if (argc < 4) {
+            printf ("Invalid usage, read comments\n") ;
+            return 0 ;
+        }
+        int ntrials = atoi (argv [3]) ;
+        int matching_type = atoi (argv [2]) ;
 
         // best answer so far
         double best_val = (matching_type == 2) ? 1e18 : 0 ;
@@ -193,7 +204,7 @@ int main (int argc, char** argv)
     // warmup for more accurate timing
     double tt = LAGraph_WallClockTime ( ) ;
     // user-provided matching type (random, heavy, light)
-    int match_type = (argc > 2) ? atoi(argv[2]) : 1;
+    int match_type = atoi (argv[2]) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
     LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, match_type, 5, msg)) ;
     tt = LAGraph_WallClockTime ( ) - tt ;

--- a/experimental/utility/LAGraph_Parent_to_S.c
+++ b/experimental/utility/LAGraph_Parent_to_S.c
@@ -43,11 +43,7 @@ int LAGraph_Parent_to_S
     GrB_Vector parent_sorted = NULL ;
     GrB_Vector sorted_permutation = NULL ;
     GrB_Matrix S = NULL ;
-
-    GrB_Index *indices ;
-    GrB_Index *vals ;
-    GrB_Index *new_labels ;     // tracks new label mapping
-    bool *new_label_assigned ;
+    
     GrB_Index nvals ;
 
     GrB_Index n ;

--- a/experimental/utility/LAGraph_Parent_to_S.c
+++ b/experimental/utility/LAGraph_Parent_to_S.c
@@ -79,13 +79,13 @@ int LAGraph_Parent_to_S
         // since vertices are 0-indexed
         n_new += (n > 0) ;
 
-        GRB_TRY (GrB_Matrix_new (&S, GrB_UINT64, n_new, n)) ;
+        GRB_TRY (GrB_Matrix_new (&S, GrB_BOOL, n_new, n)) ;
 
         GRB_TRY (GrB_free (&parent_sorted)) ;
         GRB_TRY (GrB_free (&sorted_permutation)) ;
     } else {
         // result dim: n by n
-        GRB_TRY (GrB_Matrix_new (&S, GrB_UINT64, n, n)) ;
+        GRB_TRY (GrB_Matrix_new (&S, GrB_BOOL, n, n)) ;
     }
 
     for (GrB_Index idx = 0; idx < n; idx++) {
@@ -93,7 +93,7 @@ int LAGraph_Parent_to_S
         GRB_TRY (GrB_Vector_extractElement (&i, parent_cpy, idx)) ;
         GrB_Index j = idx ;
         // printf("set (%lld, %lld) to 1\n", i, j);    
-        GRB_TRY (GrB_Matrix_setElement (S, 1, i, j)) ;
+        GRB_TRY (GrB_Matrix_setElement (S, true, i, j)) ;
     }
 
     (*result) = S ;


### PR DESCRIPTION
* Previously, the coarsening algorithm could overflow when `combine_weights = true` when two edges are combined during a coarsening step. In addition, matrices of type `GrB_BOOL` would not combine edge weights at all since all integers cast to `true`. To fix this, non-float input matrices are not used as is, instead a new `GrB_INT64` matrix using their entries is built.
* Added description of outputs to coarsening code
* Fixed type of `S` matrix in `LAGraph_Parent_to_S` to be `GrB_BOOL`. 