### PR TITLE
Cleaned up coarsening function

### DIFF
--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
     GrB_Matrix A = G->A ;
 
-    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 1, 1, 1, 67, msg)) ;
+    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 1, 0, 1, 67, msg)) ;
     LAGRAPH_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
     // LAGRAPH_TRY (LAGraph_Vector_Print (mappings[0], LAGraph_COMPLETE, stdout, msg)) ;
     /*

--- a/experimental/utility/LAGraph_Parent_to_S.c
+++ b/experimental/utility/LAGraph_Parent_to_S.c
@@ -79,13 +79,13 @@ int LAGraph_Parent_to_S
         // since vertices are 0-indexed
         n_new += (n > 0) ;
 
-        GRB_TRY (GrB_Matrix_new (&S, GrB_BOOL, n_new, n)) ;
+        GRB_TRY (GrB_Matrix_new (&S, GrB_UINT64, n_new, n)) ;
 
         GRB_TRY (GrB_free (&parent_sorted)) ;
         GRB_TRY (GrB_free (&sorted_permutation)) ;
     } else {
         // result dim: n by n
-        GRB_TRY (GrB_Matrix_new (&S, GrB_BOOL, n, n)) ;
+        GRB_TRY (GrB_Matrix_new (&S, GrB_UINT64, n, n)) ;
     }
 
     for (GrB_Index idx = 0; idx < n; idx++) {
@@ -93,7 +93,7 @@ int LAGraph_Parent_to_S
         GRB_TRY (GrB_Vector_extractElement (&i, parent_cpy, idx)) ;
         GrB_Index j = idx ;
         // printf("set (%lld, %lld) to 1\n", i, j);    
-        GRB_TRY (GrB_Matrix_setElement (S, true, i, j)) ;
+        GRB_TRY (GrB_Matrix_setElement (S, 1, i, j)) ;
     }
 
     (*result) = S ;


### PR DESCRIPTION
### Changes to `LAGraph_Coarsen_Matching`:
* Fixed slow construction of `node_parent` with the help of @DrTimothyAldenDavis .
* Removed unnecessary resizing of structures, instead freeing and rebuilding them. Resizing is expensive since we don't need the contents of the resized structure.
* Changed type of `S` matrix back to `GrB_UINT64`; using `GrB_BOOL` breaks combining edge weights.
### Changes to `LAGraph_Parent_to_S`:
* Reverted type of `S` matrix as described above.