### PR TITLE
Small fixes to LAGraph_Coarsen_Matching, new relabeling method for LAGraph_Parent_to_S

### DIFF
--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
     GrB_Matrix A = G->A ;
 
-    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 1, 0, 1, 67, msg)) ;
+    LAGRAPH_TRY (LAGraph_Coarsen_Matching (&coarsened, &mappings, G, LAGraph_Matching_random, 0, 1, 1, 67, msg)) ;
     LAGRAPH_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
     // LAGRAPH_TRY (LAGraph_Vector_Print (mappings[0], LAGraph_COMPLETE, stdout, msg)) ;
     /*


### PR DESCRIPTION
Changes to `LAGraph_Coarsen_Matching`:
* Improved allocation/freeing of structures if `preserve_mapping = true`
* Fixed bug in constructing `S` matrix if `preserve_mapping = false`
* Fixed return value of parent mappings to be sparse

Changes to `LAGraph_Parent_to_S`:
* Developed new method for relabeling nodes if `preserve_mapping = true`: improves from looping over all nodes to looping only over discarded nodes and performing sequence of `GrB_apply`'s. More details in code.