### PR TITLE
Comment cleanups, added inverse new labels result for CoarsenMatching

### DIFF
--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
     GrB_Index n ;
     GRB_TRY (GrB_Matrix_nrows (&n, G->A)) ;
     GrB_Matrix coarsened = NULL ;
-    GrB_Vector *parent_result = NULL , *newlabels_result = NULL ;
+    GrB_Vector *parent_result = NULL, *newlabels_result = NULL, *inv_newlabels_result = NULL ;
 
     int nt = NTHREAD_LIST ;
     
@@ -91,15 +91,17 @@ int main(int argc, char **argv)
     // warmup for more accurate timing
     double tt = LAGraph_WallClockTime ( ) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
-    // int res = (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
+    LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, &inv_newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
 
     tt = LAGraph_WallClockTime ( ) - tt ;
 
     GRB_TRY (GrB_free (&coarsened)) ;
     GRB_TRY (GrB_free (parent_result)) ; // free vector (first list element)
     GRB_TRY (GrB_free (newlabels_result)) ;
+    GRB_TRY (GrB_free (inv_newlabels_result)) ;
     LG_TRY (LAGraph_Free ((void**)(&parent_result), msg)) ; // free pointer to list
     LG_TRY (LAGraph_Free ((void**)(&newlabels_result), msg)) ;
+    LG_TRY (LAGraph_Free ((void**)(&inv_newlabels_result), msg)) ;
 #ifdef VERBOSE
     printf ("warmup time %g sec\n", tt) ;
 #endif
@@ -128,15 +130,18 @@ int main(int argc, char **argv)
             int64_t seed = trial * n + 1 ;
             double tt = LAGraph_WallClockTime ( ) ;
 
-            // LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
+            LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, &inv_newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
 
             tt = LAGraph_WallClockTime ( ) - tt ;
 
             GRB_TRY (GrB_free (&coarsened)) ;
             GRB_TRY (GrB_free (parent_result)) ; // free vector (first list element)
             GRB_TRY (GrB_free (newlabels_result)) ;
-            LG_TRY (LAGraph_Free ((void**)(&parent_result), msg)) ;    // free pointer to list
+            GRB_TRY (GrB_free (inv_newlabels_result)) ;
+            LG_TRY (LAGraph_Free ((void**)(&parent_result), msg)) ; // free pointer to list
             LG_TRY (LAGraph_Free ((void**)(&newlabels_result), msg)) ;
+            LG_TRY (LAGraph_Free ((void**)(&inv_newlabels_result), msg)) ;
+            
 #ifdef VERBOSE
             printf ("trial: %2d time: %10.7f sec\n", trial, tt) ;
 #endif

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -11,12 +11,9 @@
 #define NTHREAD_LIST 1
 #define THREAD_LIST 8
 
+
 int main(int argc, char **argv)
 {
-    /*
-    strategy:
-    either stdin, file, or random
-    */
     char msg [LAGRAPH_MSG_LEN] ;
 
     LAGraph_Graph G = NULL ;
@@ -31,13 +28,12 @@ int main(int argc, char **argv)
 
     // using -r will build a random graph
     bool random = (strcmp (matrix_name, "-r") == 0) ;
-    bool force_stdin = (strcmp (matrix_name, "stdin") == 0) ;
 
     LG_TRY (LAGraph_Random_Init (msg)) ;
 
     if (!random) {
         LG_TRY (readproblem (&G, NULL,
-            true, true, false, GrB_FP64, false, force_stdin ? 1 : argc, argv)) ;
+            true, true, false, GrB_FP64, false, argc, argv)) ;
     } else {
         GrB_Index n = (argc > 2 ? atoi (argv [2]) : DEFAULT_SIZE) ;
         double density = (argc > 3 ? atof (argv [3]) : DEFAULT_DENSITY) ;
@@ -95,7 +91,7 @@ int main(int argc, char **argv)
     // warmup for more accurate timing
     double tt = LAGraph_WallClockTime ( ) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
-    int res = (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
+    // int res = (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
 
     tt = LAGraph_WallClockTime ( ) - tt ;
 
@@ -132,7 +128,7 @@ int main(int argc, char **argv)
             int64_t seed = trial * n + 1 ;
             double tt = LAGraph_WallClockTime ( ) ;
 
-            LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
+            // LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabels_result, G, LAGraph_Matching_heavy, 0, 1, 1, DEFAULT_SEED, msg)) ;
 
             tt = LAGraph_WallClockTime ( ) - tt ;
 
@@ -169,30 +165,4 @@ int main(int argc, char **argv)
     LG_TRY (LAGraph_Finalize (msg)) ;
     return (GrB_SUCCESS) ;
 
-    /*
-    GrB_Vector *all_parents, *all_mappings ;
-    GrB_Matrix coarsened ;
-
-    GrB_Matrix A = G->A ;
-
-    LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &all_parents, &all_mappings, G, LAGraph_Matching_random, 0, 1, 1, 17, msg)) ;
-    LG_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
-    // LG_TRY (LAGraph_Vector_Print (all_parents[0], LAGraph_COMPLETE, stdout, msg)) ;
-    // LG_TRY (LAGraph_Vector_Print (all_mappings[0], LAGraph_COMPLETE, stdout, msg)) ;
-    /*
-    char msg[1024] ;
-    LAGraph_Init (msg) ;
-    LAGraph_Random_Init (msg) ;
-    GrB_Matrix test = NULL , test2 = NULL ;
-    GRB_TRY (LAGraph_Random_Matrix (&test, GrB_BOOL, 3, 5, 0.5, 42, msg)) ;
-    GRB_TRY (LAGraph_Random_Matrix (&test2, GrB_BOOL, 5, 3, 0.2, 93, msg)) ;
-    GRB_TRY (GrB_transpose (test2, NULL, NULL, test, NULL)) ;
-    return (GrB_SUCCESS) ;
-
-    3 3 4
-    1 2 1.7
-    1 3 0.5
-    2 1 1.7
-    3 1 0.5
-    */
 }

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -912,8 +912,9 @@ int LAGraph_Coarsen_Matching
 (
     // outputs:
     GrB_Matrix *coarsened,                   // coarsened adjacency
-    GrB_Vector **parent_result,              // parent mapping for each level; if preserve_mapping is true, is NULL
-    GrB_Vector **newlabels_result,           // new node labels for each leve; if preserve_mapping is true, is NULL
+    GrB_Vector **parent_result,              // description in LAGraph_CoarsenMatching
+    GrB_Vector **newlabels_result,           // description in LAGraph_CoarsenMatching
+    GrB_Vector **inv_newlabels_result,       // description in LAGraph_CoarsenMatching
     // inputs:
     LAGraph_Graph G,
     LAGraph_Matching_kind matching_type,     // refer to above enum


### PR DESCRIPTION
Changes to `LAGraph_Coarsen_Matching`:
* Cleaned up code description/corrected inaccurate comments
* Added `inv_newlabels` return value
* Added option to disable `parent`/`newlabels`/`inv_newlabels` return values by passing `NULL` pointer

Changes to `test_Coarsen_Matching`
* Added test for passing `NULL` pointers for return values

Changes to `LG_check_coarsen`:
* Added checking for `inv_newlabels`
* Further specified input requirements in comments
