### PR TITLE
Performance improvements for coarsening/matching

### DIFF
--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -49,6 +49,9 @@ int main(int argc, char **argv)
         LG_TRY (LAGraph_DeleteSelfEdges (G, msg)) ;
         // LG_TRY (LAGraph_Graph_Print (G, LAGraph_COMPLETE, stdout, msg)) ;
     }
+    if (burble) {
+        printf("================ DONE WITH MATRIX BUILDING ================\n") ;
+    }
     GrB_Index n ;
     GRB_TRY (GrB_Matrix_nrows (&n, G->A)) ;
     GrB_Matrix coarsened = NULL ;
@@ -87,7 +90,9 @@ int main(int argc, char **argv)
 #ifdef VERBOSE
     printf ("\n") ;
 #endif
-
+    if (burble) {
+        printf("================ STARTING WARMUP ================\n") ;
+    }
     // warmup for more accurate timing
     double tt = LAGraph_WallClockTime ( ) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
@@ -102,6 +107,9 @@ int main(int argc, char **argv)
     LG_TRY (LAGraph_Free ((void**)(&parent_result), msg)) ; // free pointer to list
     LG_TRY (LAGraph_Free ((void**)(&newlabels_result), msg)) ;
     LG_TRY (LAGraph_Free ((void**)(&inv_newlabels_result), msg)) ;
+    if (burble) {
+        printf("================ WARMUP DONE ================\n") ;
+    }
 #ifdef VERBOSE
     printf ("warmup time %g sec\n", tt) ;
 #endif

--- a/experimental/benchmark/matching-tests/bench.py
+++ b/experimental/benchmark/matching-tests/bench.py
@@ -31,12 +31,13 @@ To add new tests, simply use the following structure:
 and add it to the tests list
 
 Notes:
-For performance tests, you want ./matching_demo to accept input via stdin, since the data.mtx
+For performance tests, you want matching_demo to accept input via stdin, since the data.mtx
 is piped to it (see the build_grb_cmd function below)
 '''
 
 import os
 from termcolor import cprint
+
 
 # How many runs to do per test (results are averaged across all runs)
 NUM_RUNS = 1
@@ -50,7 +51,7 @@ tests = [
     {
         'type': 'bipartite',
         'performance': True,
-        'args': '1000 100 1 1 0 0',
+        'args': '1000000 10 1 1 0 0',
         'grb_args': 'stdin 0',
         'islight': False,
         'arg_names': 'num_nodes,sparse_factor,perf,is_naive,weighted,prefer_light',

--- a/experimental/benchmark/matching-tests/gen_bipartite.cpp
+++ b/experimental/benchmark/matching-tests/gen_bipartite.cpp
@@ -8,7 +8,8 @@ Usage:
 num_nodes [int]: How many nodes to include in the randomly generated graph
 sparse_factor [double]: Average degree of each node in the random graph
 perf [0/1]: Whether to output performance data (running time) or the produced matching details. Note that the exact (maximum) method can not be benchmarked for performance.
-naive [0/1]: Whether to evaluate the matching of the random graph using the naive method or exact (maximum) method. Described further below. naive = 1 always if perf = 1.
+naive [0/1]: Whether to evaluate the matching of the random graph using the naive method or exact (maximum) method. Described further below. naive = 1 always if perf = 1; in this case,
+the value of the input is ignored despite still being required.
 weighted [0/1]: IF naive = 1, specifies if the random graph (and matching) should be weighted. Note that the exact (maximum) method can not run on weighted graphs.
 prefer_light [0/1]: IF the graph is weighted, then specifies whether to give preference to light matchings or heavy matchings. Ignored if weighted = 0.
 

--- a/experimental/benchmark/matching_demo.c
+++ b/experimental/benchmark/matching_demo.c
@@ -121,7 +121,7 @@ int main (int argc, char** argv)
         for (int trial = 0 ; trial < ntrials ; trial++) {
             int64_t seed = trial * n + 1 ;
             
-            LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, matching_type, seed, msg)) ;
+            LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, E_t, matching_type, seed, msg)) ;
             double matching_value = 0 ;
             if (matching_type != 0) {
                 // weighted matching; need to compute total weight of matching
@@ -198,7 +198,7 @@ int main (int argc, char** argv)
     // user-provided matching type (random, heavy, light)
     int match_type = atoi (argv [2]) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
-    LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, match_type, 5, msg)) ;
+    LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, E_t, match_type, 5, msg)) ;
     tt = LAGraph_WallClockTime ( ) - tt ;
     GRB_TRY (GrB_free (&matching)) ;
 #ifdef VERBOSE
@@ -229,7 +229,7 @@ int main (int argc, char** argv)
         {
             int64_t seed = trial * n + 1 ;
             double tt = LAGraph_WallClockTime ( ) ;
-            LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, match_type, seed, msg)) ;
+            LAGRAPH_TRY (LAGraph_MaximalMatching (&matching, E, E_t, match_type, seed, msg)) ;
             tt = LAGraph_WallClockTime ( ) - tt ;
             GRB_TRY (GrB_free (&matching)) ;
 #ifdef VERBOSE

--- a/experimental/test/test_MaximalMatching.c
+++ b/experimental/test/test_MaximalMatching.c
@@ -234,7 +234,7 @@ void test_MaximalMatching (void)
         // run max matching
         for (int i = 0; i < SEEDS_PER_TEST; i++){
             // try random seeds
-            OK (LAGraph_MaximalMatching (&matching, E, tests [k].matching_type, seed, msg)) ;
+            OK (LAGraph_MaximalMatching (&matching, E, E_t, tests [k].matching_type, seed, msg)) ;
             // check correctness
             OK (GrB_mxv (node_degree, NULL, NULL, LAGraph_plus_one_uint64, E, matching, NULL)) ;
             GrB_Index max_degree ;
@@ -326,12 +326,17 @@ void test_MaximalMatchingErrors (void)
     OK (GrB_Matrix_new (&E, GrB_FP64, 1, 1)) ;
 
     // result pointer is null
-    int result = LAGraph_MaximalMatching (NULL, E, 0, 0, msg) ;
+    int result = LAGraph_MaximalMatching (NULL, E, E, 0, 0, msg) ;
     printf ("\nresult: %d %s\n", result, msg) ;
     TEST_CHECK (result == GrB_NULL_POINTER) ;
 
     // E matrix is null
-    result = LAGraph_MaximalMatching (&matching, NULL, 0, 0, msg) ;
+    result = LAGraph_MaximalMatching (&matching, NULL, E, 0, 0, msg) ;
+    printf ("\nresult: %d %s\n", result, msg) ;
+    TEST_CHECK (result == GrB_NULL_POINTER) ;
+
+    // E_t matrix is null
+    result = LAGraph_MaximalMatching (&matching, E, NULL, 0, 0, msg) ;
     printf ("\nresult: %d %s\n", result, msg) ;
     TEST_CHECK (result == GrB_NULL_POINTER) ;
 }

--- a/experimental/utility/LAGraph_Incidence_Matrix.c
+++ b/experimental/utility/LAGraph_Incidence_Matrix.c
@@ -86,6 +86,9 @@ int LAGraph_Incidence_Matrix
     GRB_TRY (GrB_Matrix_new (&E, type, num_nodes, num_edges)) ;
     GRB_TRY (GrB_Matrix_new (&E_half, type, num_nodes, num_edges)) ;
 
+    // (*result) = E ;
+    // return (GrB_SUCCESS) ;
+
     // get just the lower triangular entries
     GRB_TRY (GrB_select (A_tril, NULL, NULL, GrB_TRIL, A, 0, NULL)) ;
 
@@ -111,7 +114,6 @@ int LAGraph_Incidence_Matrix
     // build E_1 with (row_indices, ramp, values)
     // build E_2 with (col_indices, ramp, values)
     // E = E_1 + E_2
-
     GRB_TRY (GrB_Matrix_build (E_half, col_indices, ramp, values, num_edges, NULL)) ;
     GRB_TRY (GrB_Matrix_build (E, row_indices, ramp, values, num_edges, NULL)) ;
 

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -902,6 +902,7 @@ int LAGraph_MaximalMatching
     GrB_Vector *matching,
     // inputs:
     GrB_Matrix E,                         // incidence matrix, not part of LAGraph_Graph (for now)
+    GrB_Matrix E_t,                       // incidence transposed
     LAGraph_Matching_kind matching_type,  // refer to above enum
     uint64_t seed,                        // random number seed
     char *msg


### PR DESCRIPTION
### Changes to `LAGraph_Coarsen_Matching`:
* Added push/pull optimization for one mxv, cutting down between 5-10% of the cost of one coarsening step. The major cost in this algorithm, according to the burble, is coming from the `LAGraph_IncidenceMatrix` function. The first `GrB_Matrix_build` call in this function takes about 17% of the runtime of one coarsening step. Other sources of significant cost include the mxms used to do $SAS^T$, as well as transposing $E$ into $E^T$
### Changes to `LAGraph_MaximalMatching`:
* Do not compute $E^T$ inside the algorithm, instead take it as input. Most of the times, if $E$ is computed then $E^T$ will also be needed/computed by the user, so we can avoid this relatively expensive computation here. This cuts down between 5-10% of the cost of a single coarsening step.
### Other changes:
* Updates to comments in custom CPP tests
* Cleaned up `OPTIMIZE_PUSH_PULL` checking in maximal matching code
* Updated calls to maximal matching to include $E^T$ on input