### PR TITLE
remove GxB_SelectOp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew extract --version=14.0.6 libomp homebrew/cask
+        # brew extract --version=14.0.6 libomp homebrew/cask
         brew install libomp@14.0.6
     - name: Get GraphBLAS binaries
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         # brew extract --version=14.0.6 libomp homebrew/cask
         # brew install libomp@14.0.6
-        brew extract libomp homebrew/cask
+        brew extract libomp
         brew install libomp
     - name: Get GraphBLAS binaries
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         # brew extract --version=14.0.6 libomp homebrew/cask
         # brew install libomp@14.0.6
-        brew extract libomp
+        brew extract libomp homebrew/cask
         brew install libomp
     - name: Get GraphBLAS binaries
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,6 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew tap libomp/cask
         brew tap-new libomp/cask
         brew extract --version=14.0.6 libomp libomp/cask
         brew install libomp@14.0.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 0, deploy_test_results: true}
-         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 1, deploy_test_results: false}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
+         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
+         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -33,12 +34,12 @@ jobs:
         export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
         export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.so
         cd build
-        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
+        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
         JOBS=2 make
         make test_coverage
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: matrix.deploy_test_results && github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      if: matrix.config.grb_version == '7.4.1' && github.event_name == 'push' && github.ref == 'refs/heads/stable'
       with:
         branch: gh-pages
         folder: build/test_coverage/
@@ -48,22 +49,21 @@ jobs:
       with:
         name: test_coverage
         path: build/test_coverage/
-      if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
   macos:
     runs-on: macos-12
     strategy:
       matrix:
         config:
-         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 0}
-         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 1}
+         - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4, conda_extension: tar.bz2}
+         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a, conda_extension: tar.bz2}
+         - {grb_version: 7.4.1, conda_grb_package_hash: ha894c9a, conda_extension: conda}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        # brew extract --version=14.0.6 libomp homebrew/cask
-        # brew install libomp@14.0.6
-        brew install libomp
+        brew extract --version=14.0.6 libomp homebrew/cask
+        brew install libomp@14.0.6
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries
@@ -83,6 +83,6 @@ jobs:
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
         echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
-        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
+        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
         JOBS=2 make
         make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,10 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew extract --version=14.0.6 libomp homebrew/cask
-        brew install libomp@14.0.6
+        # brew extract --version=14.0.6 libomp homebrew/cask
+        # brew install libomp@14.0.6
+        brew extract libomp homebrew/cask
+        brew install libomp
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,7 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew extract --version=14.0.6 libomp homebrew/cask
-        brew install libomp@14.0.6
+        brew install libomp
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
-         - {grb_version: 7.3.0, conda_grb_package_hash: h27087fc, conda_extension: tar.bz2}
-         - {grb_version: 7.4.1, conda_grb_package_hash: hcb278e6, conda_extension: conda}
+         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 0, deploy_test_results: true}
+         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 1, deploy_test_results: false}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -34,12 +33,12 @@ jobs:
         export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
         export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.so
         cd build
-        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
+        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
         JOBS=2 make
         make test_coverage
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: matrix.config.grb_version == '7.4.1' && github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      if: matrix.deploy_test_results && github.event_name == 'push' && github.ref == 'refs/heads/stable'
       with:
         branch: gh-pages
         folder: build/test_coverage/
@@ -49,23 +48,21 @@ jobs:
       with:
         name: test_coverage
         path: build/test_coverage/
+      if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
   macos:
     runs-on: macos-12
     strategy:
       matrix:
         config:
-         - {grb_version: 7.1.0, conda_grb_package_hash: h7881ed4, conda_extension: tar.bz2}
-         - {grb_version: 7.3.0, conda_grb_package_hash: ha894c9a, conda_extension: tar.bz2}
-         - {grb_version: 7.4.1, conda_grb_package_hash: ha894c9a, conda_extension: conda}
+         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 0}
+         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        # brew extract --version=14.0.6 libomp homebrew/cask
-        # brew install libomp@14.0.6
-        # brew extract libomp homebrew/cask
-        brew install libomp
+        brew extract --version=14.0.6 libomp homebrew/cask
+        brew install libomp@14.0.6
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries
@@ -85,6 +82,6 @@ jobs:
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
         echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
-        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
+        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
         JOBS=2 make
         make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         # brew extract --version=14.0.6 libomp homebrew/cask
         # brew install libomp@14.0.6
-        brew extract libomp homebrew/cask
+        # brew extract libomp homebrew/cask
         brew install libomp
     - name: Get GraphBLAS binaries
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,10 @@ jobs:
       uses: actions/checkout@v2.0.0
     - name: Install dependencies
       run: |
-        brew install libomp
+        brew tap libomp/cask
+        brew tap-new libomp/cask
+        brew extract --version=14.0.6 libomp libomp/cask
+        brew install libomp@14.0.6
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
     - name: Install dependencies
       run: |
         # brew extract --version=14.0.6 libomp homebrew/cask
-        brew install libomp@14.0.6
+        # brew install libomp@14.0.6
+        brew install libomp
     - name: Get GraphBLAS binaries
       run: |
         mkdir graphblas-binaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,10 @@ cmake_policy ( SET CMP0048 NEW )
 set ( CMAKE_MACOSX_RPATH TRUE )
 
 # version of LAGraph
-set ( LAGraph_DATE "Dec 28, 2022" )
+set ( LAGraph_DATE "July 21, 2022" )
 set ( LAGraph_VERSION_MAJOR 1 )
 set ( LAGraph_VERSION_MINOR 0 )
-set ( LAGraph_VERSION_SUB   1 )
+set ( LAGraph_VERSION_SUB   2 )
 
 project ( lagraph
           VERSION "${LAGraph_VERSION_MAJOR}.${LAGraph_VERSION_MINOR}.${LAGraph_VERSION_SUB}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # LAGraph/CMakeLists.txt:  cmake script for LAGraph
 #-------------------------------------------------------------------------------
 
-# LAGraph, (c) 2019-2022 by The LAGraph Contributors, All Rights Reserved.
+# LAGraph, (c) 2019-2023 by The LAGraph Contributors, All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # For additional details (including references to third party source code and
@@ -49,7 +49,7 @@ cmake_policy ( SET CMP0048 NEW )
 set ( CMAKE_MACOSX_RPATH TRUE )
 
 # version of LAGraph
-set ( LAGraph_DATE "July 21, 2022" )
+set ( LAGraph_DATE "Aug 2, 2023" )
 set ( LAGraph_VERSION_MAJOR 1 )
 set ( LAGraph_VERSION_MINOR 0 )
 set ( LAGraph_VERSION_SUB   2 )

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Version 1.0.2: July 21, 2022
+
+    * port: removed GxB_SelectOp so LAGraph v1.0.2 can be compiled with
+        SuiteSparse:GraphBLAS v8.x.
+
 Version 1.0.1: Dec 26, 2022
 
     * bug fix: LAGraph_MMWrite incorrectly created a Matrix Market

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Version 1.0.2: July 21, 2022
+Version 1.0.2: Aug 2, 2023
 
     * port: removed GxB_SelectOp so LAGraph v1.0.2 can be compiled with
         SuiteSparse:GraphBLAS v8.x.

--- a/experimental/algorithm/LAGraph_msf.c
+++ b/experimental/algorithm/LAGraph_msf.c
@@ -88,6 +88,8 @@ static GrB_Index *weight = NULL, *parent = NULL, *partner = NULL;
 // for each element A(i, j), it is selected if
 //   1. weight[i] == A(i, j)    -- where weight[i] stores i's minimum edge weight
 //   2. parent[j] == partner[i] -- j belongs to the specified connected component
+#if 0
+// for GxB_SelectOp:
 bool f1 (
     GrB_Index i, GrB_Index j,
     const void *x, const void *thunk)
@@ -96,8 +98,19 @@ bool f1 (
     return (weight[i] == *aij) && (parent[j] == partner[i]);
 }
 
+#else
+// for GrB_IndexUnaryOp:
+void f1 (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
+{
+    uint64_t *aij = (uint64_t*) x;
+    (*z) = (weight[i] == *aij) && (parent[j] == partner[i]);
+}
+#endif
+
 // edge removal:
 // A(i, j) is removed when parent[i] == parent[j]
+#if 0
+// for GxB_SelectOp:
 bool f2 (
     GrB_Index i, GrB_Index j,
     const void *x, const void *thunk)
@@ -105,6 +118,14 @@ bool f2 (
     uint64_t *aij = (uint64_t*) x;
     return (parent[i] != parent[j]);
 }
+#else
+// for GrB_IndexUnaryOp:
+void f2 (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
+{
+    uint64_t *aij = (uint64_t*) x;
+    (*z) = (parent[i] != parent[j]);
+}
+#endif
 
 //****************************************************************************
 //****************************************************************************
@@ -134,7 +155,11 @@ int LAGraph_msf
     GrB_Semiring combMin = NULL;
     GrB_UnaryOp fst = NULL, snd = NULL;
 
+#if 0
     GxB_SelectOp s1 = NULL, s2 = NULL;
+#else
+    GrB_IndexUnaryOp s1 = NULL, s2 = NULL;
+#endif
     if (result == NULL || A == NULL) return (GrB_NULL_POINTER) ;
 
     GrB_Index ncols ;
@@ -190,8 +215,14 @@ int LAGraph_msf
     GRB_TRY (GrB_UnaryOp_new (&snd, get_snd, GrB_UINT64, GrB_UINT64));
 
     // GrB_SelectOp
+
+#if 0
     GxB_SelectOp_new (&s1, f1, GrB_UINT64, GrB_NULL);
     GxB_SelectOp_new (&s2, f2, GrB_UINT64, GrB_NULL);
+#else
+    GrB_IndexUnaryOp_new (&s1, (void *) f1, GrB_BOOL, GrB_UINT64, GrB_UINT64);
+    GrB_IndexUnaryOp_new (&s2, (void *) f2, GrB_BOOL, GrB_UINT64, GrB_UINT64);
+#endif
 
     // the main computation
     GrB_Index nvals, diff, ntuples = 0, num;
@@ -242,7 +273,11 @@ int LAGraph_msf
         GRB_TRY (GrB_assign (t, 0, 0, inf, GrB_ALL, 0, 0));
         GRB_TRY (GrB_apply (t, mask, 0, snd, edge, 0));
         GRB_TRY (GrB_Vector_extractTuples (I, partner, &n, t));
+#if 0
         GRB_TRY (GxB_select (T, 0, 0, s1, S, GrB_NULL, 0));
+#else
+        GRB_TRY (GrB_select (T, 0, 0, s1, S, 0, 0));
+#endif
         GRB_TRY (GrB_Vector_clear (t));
 
         // 5. the generated matrix may still have redundant edges
@@ -268,7 +303,11 @@ int LAGraph_msf
 
         // remove the edges in the same connected component
         GRB_TRY (GrB_Vector_extractTuples (I, parent, &n, f));
+#if 0
         GRB_TRY (GxB_select (S, 0, 0, s2, S, GrB_NULL, 0));
+#else
+        GRB_TRY (GrB_select (S, 0, 0, s2, S, 0, 0));
+#endif
         GrB_Matrix_nvals (&nvals, S);
         if (nvals == 0) break;
     }

--- a/experimental/algorithm/LAGraph_msf.c
+++ b/experimental/algorithm/LAGraph_msf.c
@@ -88,44 +88,18 @@ static GrB_Index *weight = NULL, *parent = NULL, *partner = NULL;
 // for each element A(i, j), it is selected if
 //   1. weight[i] == A(i, j)    -- where weight[i] stores i's minimum edge weight
 //   2. parent[j] == partner[i] -- j belongs to the specified connected component
-#if 0
-// for GxB_SelectOp:
-bool f1 (
-    GrB_Index i, GrB_Index j,
-    const void *x, const void *thunk)
-{
-    uint64_t *aij = (uint64_t*) x;
-    return (weight[i] == *aij) && (parent[j] == partner[i]);
-}
-
-#else
-// for GrB_IndexUnaryOp:
 void f1 (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
 {
     uint64_t *aij = (uint64_t*) x;
     (*z) = (weight[i] == *aij) && (parent[j] == partner[i]);
 }
-#endif
 
 // edge removal:
 // A(i, j) is removed when parent[i] == parent[j]
-#if 0
-// for GxB_SelectOp:
-bool f2 (
-    GrB_Index i, GrB_Index j,
-    const void *x, const void *thunk)
-{
-    uint64_t *aij = (uint64_t*) x;
-    return (parent[i] != parent[j]);
-}
-#else
-// for GrB_IndexUnaryOp:
 void f2 (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
 {
-    uint64_t *aij = (uint64_t*) x;
     (*z) = (parent[i] != parent[j]);
 }
-#endif
 
 //****************************************************************************
 //****************************************************************************
@@ -155,11 +129,7 @@ int LAGraph_msf
     GrB_Semiring combMin = NULL;
     GrB_UnaryOp fst = NULL, snd = NULL;
 
-#if 0
-    GxB_SelectOp s1 = NULL, s2 = NULL;
-#else
     GrB_IndexUnaryOp s1 = NULL, s2 = NULL;
-#endif
     if (result == NULL || A == NULL) return (GrB_NULL_POINTER) ;
 
     GrB_Index ncols ;
@@ -215,14 +185,8 @@ int LAGraph_msf
     GRB_TRY (GrB_UnaryOp_new (&snd, get_snd, GrB_UINT64, GrB_UINT64));
 
     // GrB_SelectOp
-
-#if 0
-    GxB_SelectOp_new (&s1, f1, GrB_UINT64, GrB_NULL);
-    GxB_SelectOp_new (&s2, f2, GrB_UINT64, GrB_NULL);
-#else
     GrB_IndexUnaryOp_new (&s1, (void *) f1, GrB_BOOL, GrB_UINT64, GrB_UINT64);
     GrB_IndexUnaryOp_new (&s2, (void *) f2, GrB_BOOL, GrB_UINT64, GrB_UINT64);
-#endif
 
     // the main computation
     GrB_Index nvals, diff, ntuples = 0, num;
@@ -273,11 +237,7 @@ int LAGraph_msf
         GRB_TRY (GrB_assign (t, 0, 0, inf, GrB_ALL, 0, 0));
         GRB_TRY (GrB_apply (t, mask, 0, snd, edge, 0));
         GRB_TRY (GrB_Vector_extractTuples (I, partner, &n, t));
-#if 0
-        GRB_TRY (GxB_select (T, 0, 0, s1, S, GrB_NULL, 0));
-#else
         GRB_TRY (GrB_select (T, 0, 0, s1, S, 0, 0));
-#endif
         GRB_TRY (GrB_Vector_clear (t));
 
         // 5. the generated matrix may still have redundant edges
@@ -303,11 +263,7 @@ int LAGraph_msf
 
         // remove the edges in the same connected component
         GRB_TRY (GrB_Vector_extractTuples (I, parent, &n, f));
-#if 0
-        GRB_TRY (GxB_select (S, 0, 0, s2, S, GrB_NULL, 0));
-#else
         GRB_TRY (GrB_select (S, 0, 0, s2, S, 0, 0));
-#endif
         GrB_Matrix_nvals (&nvals, S);
         if (nvals == 0) break;
     }

--- a/experimental/algorithm/LAGraph_scc.c
+++ b/experimental/algorithm/LAGraph_scc.c
@@ -48,21 +48,11 @@ GrB_Index *I = NULL, *V = NULL, *F = NULL, *B = NULL, *M = NULL;
 // an edge (u, v) if either F[u]!=F[v] or B[u]!=B[v] holds, which can accelerate
 // the SCC computation in the future rounds.
 
-#if 0
-// using GxB_SelectOp
-bool edge_removal (GrB_Index i, GrB_Index j, const void *x, const void *thunk) ;
-bool edge_removal (GrB_Index i, GrB_Index j, const void *x, const void *thunk)
-{
-    return !M[i] && !M[j] && F[i] == F[j] && B[i] == B[j];
-}
-#else
-// using GrB_IndexUnaryOp
 void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk) ;
 void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
 {
     (*z) = (!M[i] && !M[j] && F[i] == F[j] && B[i] == B[j]) ;
 }
-#endif
 
 //****************************************************************************
 // trim_one: remove the edges connected to trivial SCCs
@@ -70,21 +60,11 @@ void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void 
 //  - M[i] = i   | if vertex i is a trivial SCC
 //    M[i] = n   | otherwise
 
-#if 0
-// using GxB_SelectOp
-bool trim_one (GrB_Index i, GrB_Index j, const void *x, const void *thunk) ;
-bool trim_one (GrB_Index i, GrB_Index j, const void *x, const void *thunk)
-{
-    return M[i] == M[j];
-}
-#else
-// using GrB_IndexUnaryOp
 void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk) ;
 void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
 {
     (*z) = (M[i] == M[j]) ;
 }
-#endif
 
 //****************************************************************************
 // label propagation
@@ -145,11 +125,7 @@ int LAGraph_scc
     GrB_Vector ind;
     GrB_Vector inf;
     GrB_Vector f, b, mask;
-#if 0
-    GxB_SelectOp sel1, sel2;
-#else
     GrB_IndexUnaryOp sel1 = NULL, sel2 = NULL ;
-#endif
     GrB_Monoid Add;
 
     if (result == NULL || A == NULL) return (GrB_NULL_POINTER) ;
@@ -195,14 +171,8 @@ int LAGraph_scc
     GRB_TRY (GrB_Vector_new (&f, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&b, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&mask, GrB_UINT64, n));
-#if 0
-    // GxB_SelectOp
-    GRB_TRY (GxB_SelectOp_new (&sel1, trim_one, GrB_BOOL, GrB_NULL));
-    GRB_TRY (GxB_SelectOp_new (&sel2, edge_removal, GrB_BOOL, GrB_NULL));
-#else
     GRB_TRY (GrB_IndexUnaryOp_new (&sel1, (void *) trim_one, GrB_BOOL, GrB_UINT64, GrB_UINT64));
     GRB_TRY (GrB_IndexUnaryOp_new (&sel2, (void *) edge_removal, GrB_BOOL, GrB_UINT64, GrB_UINT64));
-#endif
 
     // remove trivial SCCs
     GRB_TRY (GrB_reduce (f, 0, GrB_PLUS_UINT64, GrB_PLUS_UINT64, FW, 0));
@@ -217,13 +187,8 @@ int LAGraph_scc
     if (nvals < n)
     {
         GRB_TRY (GrB_Vector_extractTuples (I, M, &n, scc));
-#if 0
-        GRB_TRY (GxB_select (FW, 0, 0, sel1, FW, GrB_NULL, 0));
-        GRB_TRY (GxB_select (BW, 0, 0, sel1, BW, GrB_NULL, 0));
-#else
         GRB_TRY (GrB_select (FW, 0, 0, sel1, FW, 0, 0));
         GRB_TRY (GrB_select (BW, 0, 0, sel1, BW, 0, 0));
-#endif
     }
 
     GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
@@ -245,13 +210,8 @@ int LAGraph_scc
         GRB_TRY (GrB_Vector_extractTuples (I, B, &n, b));
         GRB_TRY (GrB_Vector_extractTuples (I, M, &n, mask));
 
-#if 0
-        GRB_TRY (GxB_select (FW, 0, 0, sel2, FW, GrB_NULL, 0));
-        GRB_TRY (GxB_select (BW, 0, 0, sel2, BW, GrB_NULL, 0));
-#else
         GRB_TRY (GrB_select (FW, 0, 0, sel2, FW, 0, 0));
         GRB_TRY (GrB_select (BW, 0, 0, sel2, BW, 0, 0));
-#endif
 
         GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
     }

--- a/include/LAGraph.h
+++ b/include/LAGraph.h
@@ -37,7 +37,7 @@
 // See also the LAGraph_Version utility method, which returns these values.
 // These definitions are derived from LAGraph/CMakeLists.txt.
 
-#define LAGRAPH_DATE "July 21, 2022"
+#define LAGRAPH_DATE "Aug 2, 2023"
 #define LAGRAPH_VERSION_MAJOR  1
 #define LAGRAPH_VERSION_MINOR  0
 #define LAGRAPH_VERSION_UPDATE 2

--- a/include/LAGraph.h
+++ b/include/LAGraph.h
@@ -37,10 +37,10 @@
 // See also the LAGraph_Version utility method, which returns these values.
 // These definitions are derived from LAGraph/CMakeLists.txt.
 
-#define LAGRAPH_DATE "Dec 28, 2022"
+#define LAGRAPH_DATE "July 21, 2022"
 #define LAGRAPH_VERSION_MAJOR  1
 #define LAGRAPH_VERSION_MINOR  0
-#define LAGRAPH_VERSION_UPDATE 1
+#define LAGRAPH_VERSION_UPDATE 2
 
 //==============================================================================
 // include files and helper macros

--- a/src/benchmark/LAGraph_demo.h
+++ b/src/benchmark/LAGraph_demo.h
@@ -1101,8 +1101,8 @@ static inline int demo_init (bool burble)
     char msg [LAGRAPH_MSG_LEN] ;
     msg [0] = '\0' ;
 
-    #ifdef __linux__
-    // Use mallopt to speedup malloc and free on Linux.  Otherwise, it can take
+    #ifdef __GLIBC__
+    // Use mallopt to speedup malloc and free on Linux (glibc).  Otherwise, it can take
     // several seconds to free a large block of memory.  For this to be
     // effective, demo_init must be called before calling malloc/free, and
     // before calling LAGraph_Init.

--- a/src/test/test_Type.c
+++ b/src/test/test_Type.c
@@ -79,14 +79,8 @@ void test_TypeName  (void)
     name [0] = '\0' ;
     OK (GrB_Type_new (&type, sizeof (myint))) ;
     int result = LAGraph_NameOfType (name, type, msg) ;
-    #if LAGRAPH_SUITESPARSE
-    printf ("\nSuiteSparse knows the type name: [%s]\n", name) ;
-    TEST_CHECK (result == GrB_SUCCESS) ;
-    OK (strcmp (name, "myint")) ;
-    #else
     TEST_CHECK (result == GrB_NOT_IMPLEMENTED) ;
     printf ("\nmsg: %s\n", msg) ;
-    #endif
 
     TEST_CHECK (LAGraph_NameOfType (NULL, NULL, msg) == GrB_NULL_POINTER) ;
     printf ("\nmsg: %s\n", msg) ;

--- a/src/utility/LAGraph_NameOfType.c
+++ b/src/utility/LAGraph_NameOfType.c
@@ -40,14 +40,6 @@ int LAGraph_NameOfType
     // determine the name of the type
     //--------------------------------------------------------------------------
 
-    #if LAGRAPH_SUITESPARSE
-
-        // always succeeds, even for user-defined types, unless the
-        // type is an invalid object
-        return (GxB_Type_name (name, type)) ;
-
-    #else
-
         if      (type == GrB_BOOL  ) strcpy (name, "bool")     ;
         else if (type == GrB_INT8  ) strcpy (name, "int8_t")   ;
         else if (type == GrB_INT16 ) strcpy (name, "int16_t")  ;
@@ -71,5 +63,4 @@ int LAGraph_NameOfType
         }
         return (GrB_SUCCESS) ;
 
-    #endif
 }


### PR DESCRIPTION
GxB_SelectOp was removed from SuiteSparse:GraphBLAS v8.x.  This minor update allows LAGraph to use SuiteSparse:GraphBLAS v7.x or v8.x.