### PR TITLE
`#ifdef __GLIBC__` for musl compatibility

### DIFF
--- a/src/benchmark/LAGraph_demo.h
+++ b/src/benchmark/LAGraph_demo.h
@@ -1101,8 +1101,8 @@ static inline int demo_init (bool burble)
     char msg [LAGRAPH_MSG_LEN] ;
     msg [0] = '\0' ;
 
-    #ifdef __linux__
-    // Use mallopt to speedup malloc and free on Linux.  Otherwise, it can take
+    #ifdef __GLIBC__
+    // Use mallopt to speedup malloc and free on Linux (glibc).  Otherwise, it can take
     // several seconds to free a large block of memory.  For this to be
     // effective, demo_init must be called before calling malloc/free, and
     // before calling LAGraph_Init.


### PR DESCRIPTION
Build can fail due to missing mallopt function in musl. Upstreaming the fix would allow me to eliminate the patch from the LAGraph JLL package build ([see pull request](https://github.com/JuliaPackaging/Yggdrasil/pull/7089)). The BuildKite run shows that all platforms build correctly with the patch included.
It would be ideal to include in the 1.0.2 release in order to avoid building a JLL with an untagged commit and potentially causing maintenance headaches.