### PR TITLE
Fixing roundoff errors in coarsening, incidence matrix construction

### DIFF
--- a/experimental/algorithm/LAGraph_Coarsen_Matching.c
+++ b/experimental/algorithm/LAGraph_Coarsen_Matching.c
@@ -302,10 +302,6 @@ int LAGraph_Coarsen_Matching
     char *msg
 )
 {
-    
-#if !LAGRAPH_SUITESPARSE
-    LG_ASSERT (false, GrB_NOT_IMPLEMENTED) ;
-#endif
 
     LG_CLEAR_MSG ;
 
@@ -332,6 +328,10 @@ int LAGraph_Coarsen_Matching
     GrB_Index nvals, nrows ;
     GrB_Type A_type ;
     // check properties (no self-loops, undirected)
+
+#if !LAGRAPH_SUITESPARSE
+    LG_ASSERT (false, GrB_NOT_IMPLEMENTED) ;
+#endif
 
     if (G->kind == LAGraph_ADJACENCY_UNDIRECTED)
     {

--- a/experimental/algorithm/LAGraph_Coarsen_Matching.c
+++ b/experimental/algorithm/LAGraph_Coarsen_Matching.c
@@ -329,9 +329,9 @@ int LAGraph_Coarsen_Matching
     GrB_Type A_type ;
     // check properties (no self-loops, undirected)
 
-#if !LAGRAPH_SUITESPARSE
-    LG_ASSERT (false, GrB_NOT_IMPLEMENTED) ;
-#endif
+// #if !LAGRAPH_SUITESPARSE
+//     LG_ASSERT (false, GrB_NOT_IMPLEMENTED) ;
+// #endif
 
     if (G->kind == LAGraph_ADJACENCY_UNDIRECTED)
     {

--- a/experimental/algorithm/LAGraph_Coarsen_Matching.c
+++ b/experimental/algorithm/LAGraph_Coarsen_Matching.c
@@ -25,7 +25,7 @@ counts the number of combined edges)
 
 There are 4 outputs from the function:
 1. A GrB_Matrix of the coarsened graph (if the input adjacency matrix is of type GrB_BOOL or GrB_UINT{8|16|32} or GrB_INT*, it will
-have type GrB_INT64. Else, it will have the same type as the input matrix).
+have type GrB_INT64. If it is of type GrB_FP32, it will have type GrB_FP64. Else, it will have the same type as the input matrix.
 
 2. A list of GrB_Vectors (parent_result) of length nlevels, where if parent_result[i][u] = v,
 then the parent of node u in G_{i} is node v in G_{i}, where G_0 is the initial graph. Note that this means 
@@ -183,12 +183,9 @@ static int LAGraph_Parent_to_S
         // build ramp vector
         LG_TRY (LAGraph_Malloc ((void**) &ramp, num_preserved, sizeof(uint64_t), msg)) ;
 
-        #pragma omp parallel
-        {
-            #pragma omp for
-            for (GrB_Index i = 0 ; i < num_preserved ; i++) {
-                ramp [i] = i ;
-            }
+        #pragma omp parallel for
+        for (GrB_Index i = 0 ; i < num_preserved ; i++) {
+            ramp [i] = i ;
         }
 
         if (inv_newlabels != NULL) {
@@ -387,10 +384,10 @@ int LAGraph_Coarsen_Matching
     else
     {
         // G is not undirected
-        LG_ASSERT_MSG (false, -105, "G must be undirected") ;
+        LG_ASSERT_MSG (false, LAGRAPH_INVALID_GRAPH, "G must be undirected") ;
     }
     CHKPT("Done with building A");
-    LG_ASSERT_MSG (G->nself_edges == 0, -107, "G->nself_edges must be zero") ;
+    LG_ASSERT_MSG (G->nself_edges == 0, LAGRAPH_NO_SELF_EDGES_ALLOWED, "G->nself_edges must be zero") ;
 
     // make new LAGraph_Graph to use for building incidence matrix and for useful functions (delete self-edges)
     LG_TRY (LAGraph_New (&G_cpy, &A, LAGraph_ADJACENCY_UNDIRECTED, msg)) ;

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -919,8 +919,8 @@ int LAGraph_Coarsen_Matching
     // inputs:
     LAGraph_Graph G,
     LAGraph_Matching_kind matching_type,     // refer to above enum
-    int preserve_mapping,                    // preserve initial namespace of nodes
-    int combine_weights,                     // whether to sum edge weights or just keep the pattern
+    bool preserve_mapping,                   // preserve initial namespace of nodes
+    bool combine_weights,                    // whether to sum edge weights or just keep the pattern
     GrB_Index nlevels,                       // #of coarsening levels
     uint64_t seed,                           // used for matching
     char *msg


### PR DESCRIPTION
* Previously, some operations in `LAGraph_IncidenceMatrix` and `LAGraph_Coarsen_Matching` were being done by casting large integers to floating point, which will cause potential roundoff errors. This PR will fix that by ensuring integers and floats cast only to other integers and floats respectively of at least the same size.
* Also performed miscellaneous code cleanups. Importantly, removed GxB function calls and fixed error codes in LG_check_coarsen (which may be used for checking against any coarsening method), and made slight changes to the Coarsen_Matching API.