### PR TITLE
Coarsening updates

### DIFF
--- a/experimental/algorithm/LAGraph_Coarsen_Matching.c
+++ b/experimental/algorithm/LAGraph_Coarsen_Matching.c
@@ -107,8 +107,8 @@ static int LAGraph_Parent_to_S
     char *msg
 )
 {
-    GrB_Vector parent_cpy = NULL ;          // don't modify input parent. Also useful to have for compressing node labels.
-    GrB_Matrix S = NULL ;
+    GrB_Vector parent_cpy = NULL ;  // used so we don't modify the input parent vector. Also useful to have for computing newlabels
+    GrB_Matrix S = NULL ;           // stores the resulting S matrix
 
     // ------------------------ BUILDING S MATRIX --------------------------
     // used to unpack parent_cpy and build S
@@ -119,8 +119,7 @@ static int LAGraph_Parent_to_S
     
 
     // ----------------------- NODE COMPRESSION -----------------------------
-    // [0...(n - 1)]
-    // No need to free this since it gets packed
+    // No need to free this since it gets packed back
     uint64_t *ramp = NULL ;
     // used to unpack preserved nodes
     // note: No need to free the array since it is packed back
@@ -154,9 +153,9 @@ static int LAGraph_Parent_to_S
         /*
         new code:
             - identify preserved nodes (GrB_select to parent_cpy)
-            - unpack to get values of preserved
-            - build ramp vector (full vector, GrB_apply w/ row index)
-            - pack back into parent_cpy with ramp as values, preserved as indices
+            - unpack to get indices of preserved nodes
+            - build ramp vector
+            - pack back into parent_cpy with ramp as values, preserved node indices as indices (performs compression)
             - GrB_extract into parent_cpy from parent_cpy with row indices as values from original parent
                 - This fills in the new parents for discarded nodes
         */
@@ -169,15 +168,15 @@ static int LAGraph_Parent_to_S
         
         // get indices of preserved nodes
         GRB_TRY (GxB_Vector_unpack_CSC (
-                parent_cpy, 
-                &preserved_indices, 
-                (void**) &preserved_values, 
-                &preserved_indices_size, 
-                &preserved_values_size, 
-                NULL, 
-                &num_preserved,
-                &is_jumbled,
-                NULL
+            parent_cpy, 
+            &preserved_indices, 
+            (void**) &preserved_values, 
+            &preserved_indices_size, 
+            &preserved_values_size, 
+            NULL, 
+            &num_preserved,
+            &is_jumbled,
+            NULL
         )) ;
         
         // build ramp vector
@@ -193,7 +192,7 @@ static int LAGraph_Parent_to_S
             GRB_TRY (GrB_Vector_build (*inv_newlabels, ramp, preserved_indices, num_preserved, NULL)) ;
         }
 
-        // pack back into parent_cpy
+        // pack back into parent_cpy (parent_cpy will now store the new labels of preserved nodes)
         GRB_TRY (GxB_Vector_pack_CSC (
             parent_cpy,
             &preserved_indices,
@@ -209,17 +208,12 @@ static int LAGraph_Parent_to_S
         LG_TRY (LAGraph_Free ((void**)(&ramp), msg)) ;
 
         if (newlabels != NULL) {
-            // alternate method:
-            // (*newlabels) = parent_cpy
-            // and free parent_cpy in LG_FREE_ALL instead of LG_FREE_WORK 
             GRB_TRY (GrB_Vector_dup (newlabels, parent_cpy)) ;
         }
 
         LG_TRY (LAGraph_Malloc ((void**) &original_indices, n, sizeof(GrB_Index), msg)) ;
         LG_TRY (LAGraph_Malloc ((void**) &original_values, n, sizeof(uint64_t), msg)) ;
 
-        // is extractTuples needed? Since this is a static function (and won't be exposed to users), 
-        // is it OK to just unpack and rip the contents of the input out?
         GRB_TRY (GrB_Vector_extractTuples (original_indices, original_values, &n, parent)) ;
 
         // fill in entries for discarded nodes
@@ -328,6 +322,10 @@ int LAGraph_Coarsen_Matching
      LG_ASSERT (false, GrB_NOT_IMPLEMENTED) ;
 #endif
 
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
+    // check input graph, build local adjacency matrix to use for coarsening
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
+
     if (G->kind == LAGraph_ADJACENCY_UNDIRECTED)
     {
         char typename[LAGRAPH_MAX_NAME_LEN] ;
@@ -388,7 +386,7 @@ int LAGraph_Coarsen_Matching
         return GrB_NULL_POINTER ;
     }
 
-    // make new LAGraph_Graph to use for building incidence matrix and for useful functions (delete self-edges)
+    // make new LAGraph_Graph to use for LAGraph_IncidenceMatrix and for useful functions (delete self-edges)
     LG_TRY (LAGraph_New (&G_cpy, &A, LAGraph_ADJACENCY_UNDIRECTED, msg)) ;
     LG_TRY (LAGraph_Cached_NSelfEdges (G_cpy, msg)) ;
 
@@ -399,15 +397,17 @@ int LAGraph_Coarsen_Matching
     GrB_Index num_edges ;
 
     GRB_TRY (GrB_Matrix_nrows (&num_nodes, A)) ;
+    GRB_TRY (GrB_Matrix_nvals (&num_edges, A)) ;
+    num_edges /= 2 ; // since undirected
+
     CHKPT("Done building G_cpy");
 
-    if (preserve_mapping) {
-        GRB_TRY (GrB_Matrix_new (&S_t, A_type, num_nodes, num_nodes)) ;
-        GRB_TRY (GrB_Vector_new (&node_parent, GrB_UINT64, num_nodes)) ;
-    }
+    GRB_TRY (GrB_Matrix_new (&E_t, A_type, num_edges, num_nodes)) ;
+    GRB_TRY (GrB_Vector_new (&edge_parent, GrB_UINT64, num_edges)) ;
+
+    GRB_TRY (GrB_Vector_new (&node_parent, GrB_UINT64, num_nodes)) ;
 
     GRB_TRY (GrB_Vector_new (&full, GrB_BOOL, num_nodes)) ;
-
     GRB_TRY (GrB_assign (full, NULL, NULL, true, GrB_ALL, num_nodes, NULL)) ;
 
     // for push/pull optimization
@@ -419,34 +419,22 @@ int LAGraph_Coarsen_Matching
     #endif
 
     GrB_Index curr_level = 0 ;
-    CHKPT("Starting main loop");
+    CHKPT("Starting coarsening step");
 
-    // ------------------------ COARSENING STEP ------------------------
-    // get E
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
+    // coarsening step
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
+
+    // get incidence matrix
     LG_TRY (LAGraph_Incidence_Matrix (&E, G_cpy, msg)) ;
     CHKPT("Done with LAGraph_IncidenceMatrix");
-    GRB_TRY (GrB_Matrix_nvals (&num_edges, A)) ;
-    num_edges /= 2 ; // since undirected
-
-    if (!preserve_mapping) {
-        GRB_TRY (GrB_Matrix_nrows (&num_nodes, A)) ;
-
-        // create node_parent for this level
-        GRB_TRY (GrB_Vector_new (&node_parent, GrB_UINT64, num_nodes)) ;
-
-        // ok to resize full since we are using its contents later
-        GRB_TRY (GrB_Vector_resize (full, num_nodes)) ;
-    }
-    
-    GRB_TRY (GrB_Matrix_new (&E_t, A_type, num_edges, num_nodes)) ;
-    GRB_TRY (GrB_Vector_new (&edge_parent, GrB_UINT64, num_edges)) ;
 
     GRB_TRY (GrB_transpose (E_t, NULL, NULL, E, NULL)) ;
     CHKPT("Starting maximal matching");
     // run maximal matching
     LG_TRY (LAGraph_MaximalMatching (&matched_edges, E, E_t, matching_type, seed, msg)) ;
     CHKPT("Done with maximal matching");
-    // TODO: Make single coarsening step a util function
+
     // make edge_parent
     // want to do E_t * full and get the first entry for each edge (mask output with matched_edges)
     GRB_TRY (GrB_mxv (edge_parent, matched_edges, NULL, GxB_MIN_SECONDI_INT64, E_t, full, GrB_DESC_RS)) ;
@@ -470,13 +458,14 @@ int LAGraph_Coarsen_Matching
         GRB_TRY (GrB_vxm (node_parent, NULL, NULL, GrB_MIN_FIRST_SEMIRING_UINT64, edge_parent, E_t, NULL)) ;
     }
 
-    // assign empty masked by singletons
+    // DO NOT apply for nodes that are singletons
+
     // populate non-existent entries in node_parent with their index
     // handles nodes that are not engaged in a matching
     GrB_apply (node_parent, node_parent, NULL, GrB_ROWINDEX_INT64, full, (uint64_t) 0, GrB_DESC_SC) ;
 
     if (parent_result != NULL) {
-        // record a deep copy of the current node_parent for the current coarsening level
+        // record a deep copy of the current node_parent for the output parent vector
         GRB_TRY (GrB_Vector_dup (parent_result, node_parent)) ;
     }
 
@@ -490,8 +479,8 @@ int LAGraph_Coarsen_Matching
     // build the S matrix
     LG_TRY (LAGraph_Parent_to_S (
         &S,
-        (newlabel_result == NULL ? NULL : newlabel_result), 
-        (inv_newlabel_result == NULL ? NULL : inv_newlabel_result),
+        newlabel_result,
+        inv_newlabel_result,
         node_parent,
         preserve_mapping, 
         A_type,
@@ -507,15 +496,15 @@ int LAGraph_Coarsen_Matching
     
     GrB_Index S_nrows, S_ncols ;
 
-    if (!preserve_mapping) {
-        // need to create S_t for this level
-        GRB_TRY (GrB_Matrix_nrows (&S_nrows, S)) ;
-        GRB_TRY (GrB_Matrix_ncols (&S_ncols, S)) ;
-        
-        GRB_TRY (GrB_Matrix_new (&S_t, A_type, S_ncols, S_nrows)) ;
-    }
+    // create S_t now that we know the dimensions of S
+    GRB_TRY (GrB_Matrix_nrows (&S_nrows, S)) ;
+    GRB_TRY (GrB_Matrix_ncols (&S_ncols, S)) ;
+    
+    GRB_TRY (GrB_Matrix_new (&S_t, A_type, S_ncols, S_nrows)) ;
+
     GRB_TRY (GrB_transpose (S_t, NULL, NULL, S, NULL)) ;
 
+    // choose right semiring based on combine_weights and type of adjacency matrix
     GrB_Semiring combine_semiring = (A_type == GrB_FP64) ? GrB_PLUS_TIMES_SEMIRING_FP64 : GrB_PLUS_TIMES_SEMIRING_INT64 ;
     GrB_Semiring semiring = combine_weights ? combine_semiring : LAGraph_any_one_bool ;
     
@@ -527,7 +516,7 @@ int LAGraph_Coarsen_Matching
     #endif
 
     if (!preserve_mapping) {
-        // resize result
+        // re-instantiate adjacency matrix with new dimensions
         GRB_TRY (GrB_free (&A)) ;
         GRB_TRY (GrB_Matrix_new (&A, A_type, S_nrows, S_nrows)) ;
     }
@@ -540,20 +529,19 @@ int LAGraph_Coarsen_Matching
     LG_TRY (LAGraph_DeleteSelfEdges (G_cpy, msg)) ;
     A = G_cpy->A ;
 
-    // want to free before we reassign what they point to
+    // free all objects
     GRB_TRY (GrB_free (&S)) ;
     GRB_TRY (GrB_free (&E)) ;
     GRB_TRY (GrB_free (&E_t)) ;
     GRB_TRY (GrB_free (&matched_edges)) ;
     GRB_TRY (GrB_free (&edge_parent)) ;
 
-    if (!preserve_mapping){
-        // also free node_parent and S_t for this level
-        GRB_TRY (GrB_free (&node_parent)) ;
-        GRB_TRY (GrB_free (&S_t)) ;
-    }
+    GRB_TRY (GrB_free (&node_parent)) ;
+    GRB_TRY (GrB_free (&S_t)) ;
 
-    // ------------------------ COARSENING STEP DONE ------------------------
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
+    // coarsening step done
+    //----------------------------------------------------------------------------------------------------------------------------------------------------
 
     (*coarsened) = A ;
     

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -4,7 +4,7 @@
 
 #define VERBOSE
 
-#define DEFAULT_SIZE 100
+#define DEFAULT_SIZE 4
 #define DEFAULT_DENSITY 0.5
 #define DEFAULT_SEED 42
 
@@ -58,6 +58,7 @@ int main(int argc, char **argv)
     GRB_TRY (GrB_Matrix_nrows (&n, G->A)) ;
     GrB_Matrix coarsened = NULL ;
     GrB_Vector parent_result = NULL, newlabel_result = NULL, inv_newlabel_result = NULL ;
+    GrB_Vector local_newlabel_result = NULL, inv_local_newlabel_result = NULL ;
 
     int nt = NTHREAD_LIST ;
     
@@ -98,7 +99,8 @@ int main(int argc, char **argv)
     // warmup for more accurate timing
     double tt = LAGraph_WallClockTime ( ) ;
     // GRB_TRY (LAGraph_Matrix_Print (E, LAGraph_COMPLETE, stdout, msg)) ;
-    LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabel_result, &inv_newlabel_result, G, LAGraph_Matching_heavy, 0, 1, DEFAULT_SEED, msg)) ;
+    LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabel_result, &inv_newlabel_result, 
+        &local_newlabel_result, &inv_local_newlabel_result, G, LAGraph_Matching_heavy, 0, 1, DEFAULT_SEED, msg)) ;
 
     tt = LAGraph_WallClockTime ( ) - tt ;
 
@@ -115,6 +117,8 @@ int main(int argc, char **argv)
     GRB_TRY (GrB_free (&parent_result)) ;
     GRB_TRY (GrB_free (&newlabel_result)) ;
     GRB_TRY (GrB_free (&inv_newlabel_result)) ;
+    GRB_TRY (GrB_free (&local_newlabel_result)) ;
+    GRB_TRY (GrB_free (&inv_local_newlabel_result)) ;
 
     if (burble) {
         printf("================ WARMUP DONE ================\n") ;
@@ -147,7 +151,8 @@ int main(int argc, char **argv)
             int64_t seed = trial * n + 1 ;
             double tt = LAGraph_WallClockTime ( ) ;
 
-            LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabel_result, &inv_newlabel_result, G, LAGraph_Matching_heavy, 0, 1, DEFAULT_SEED, msg)) ;
+            LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabel_result, &inv_newlabel_result, 
+                &local_newlabel_result, &inv_local_newlabel_result, G, LAGraph_Matching_heavy, 0, 1, DEFAULT_SEED, msg)) ;
 
             tt = LAGraph_WallClockTime ( ) - tt ;
 
@@ -155,6 +160,8 @@ int main(int argc, char **argv)
             GRB_TRY (GrB_free (&parent_result)) ;
             GRB_TRY (GrB_free (&newlabel_result)) ;
             GRB_TRY (GrB_free (&inv_newlabel_result)) ;
+            GRB_TRY (GrB_free (&local_newlabel_result)) ;
+            GRB_TRY (GrB_free (&inv_local_newlabel_result)) ;
             
 #ifdef VERBOSE
             printf ("trial: %2d time: %10.7f sec\n", trial, tt) ;

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -4,14 +4,14 @@
 
 #define VERBOSE
 
-#define DEFAULT_SIZE 4
-#define DEFAULT_DENSITY 0.5
+#define DEFAULT_SIZE 10000000000
+#define DEFAULT_DENSITY 0.000000000000001
 #define DEFAULT_SEED 42
 
 #define NTHREAD_LIST 0
 #define THREAD_LIST 8
 
-// #define SHOW_RESULTS
+#define SHOW_RESULTS
 
 
 int main(int argc, char **argv)
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
 
     LAGraph_Graph G = NULL ;
 
-    bool burble = false ; 
+    bool burble = true ; 
     demo_init (burble) ;
 
     //--------------------------------------------------------------------------
@@ -105,12 +105,16 @@ int main(int argc, char **argv)
     tt = LAGraph_WallClockTime ( ) - tt ;
 
 #ifdef SHOW_RESULTS
+    printf("printing original adjacency:\n") ;
+    LG_TRY (LAGraph_Matrix_Print (G->A, LAGraph_COMPLETE, stdout, msg)) ;
     printf("printing coarsened adjacency:\n") ;
     LG_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
     printf("printing parent vec:\n") ;
     LG_TRY (LAGraph_Vector_Print (parent_result, LAGraph_COMPLETE, stdout, msg)) ;
     printf("printing newlabel vec:\n") ;
     LG_TRY (LAGraph_Vector_Print (newlabel_result, LAGraph_COMPLETE, stdout, msg)) ;
+    printf("printing local newlabel vec:\n") ;
+    LG_TRY (LAGraph_Vector_Print (local_newlabel_result, LAGraph_COMPLETE, stdout, msg)) ;
 #endif
 
     GRB_TRY (GrB_free (&coarsened)) ;

--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -4,12 +4,14 @@
 
 #define VERBOSE
 
-#define DEFAULT_SIZE 10000
+#define DEFAULT_SIZE 100
 #define DEFAULT_DENSITY 0.5
 #define DEFAULT_SEED 42
 
 #define NTHREAD_LIST 0
 #define THREAD_LIST 8
+
+// #define SHOW_RESULTS
 
 
 int main(int argc, char **argv)
@@ -18,7 +20,7 @@ int main(int argc, char **argv)
 
     LAGraph_Graph G = NULL ;
 
-    bool burble = true ; 
+    bool burble = false ; 
     demo_init (burble) ;
 
     //--------------------------------------------------------------------------
@@ -99,6 +101,15 @@ int main(int argc, char **argv)
     LG_TRY (LAGraph_Coarsen_Matching (&coarsened, &parent_result, &newlabel_result, &inv_newlabel_result, G, LAGraph_Matching_heavy, 0, 1, DEFAULT_SEED, msg)) ;
 
     tt = LAGraph_WallClockTime ( ) - tt ;
+
+#ifdef SHOW_RESULTS
+    printf("printing coarsened adjacency:\n") ;
+    LG_TRY (LAGraph_Matrix_Print (coarsened, LAGraph_COMPLETE, stdout, msg)) ;
+    printf("printing parent vec:\n") ;
+    LG_TRY (LAGraph_Vector_Print (parent_result, LAGraph_COMPLETE, stdout, msg)) ;
+    printf("printing newlabel vec:\n") ;
+    LG_TRY (LAGraph_Vector_Print (newlabel_result, LAGraph_COMPLETE, stdout, msg)) ;
+#endif
 
     GRB_TRY (GrB_free (&coarsened)) ;
     GRB_TRY (GrB_free (&parent_result)) ;

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -912,16 +912,19 @@ LAGRAPH_PUBLIC
 int LAGraph_Coarsen_Matching
 (
     // outputs:
-    GrB_Matrix *coarsened,                  // coarsened adjacency
-    GrB_Vector *parent_result,              // description in LAGraph_CoarsenMatching
-    GrB_Vector *newlabel_result,            // description in LAGraph_CoarsenMatching
-    GrB_Vector *inv_newlabel_result,        // description in LAGraph_CoarsenMatching
+    GrB_Matrix *coarsened,                 // coarsened adjacency (refer to further details at top of file)
+    GrB_Vector *parent_result,             // description in LAGraph_Coarsen_Matching
+    GrB_Vector *newlabel_result,           // description in LAGraph_Coarsen_Matching
+    GrB_Vector *inv_newlabel_result,       // description in LAGraph_Coarsen_Matching
+    GrB_Vector *local_newlabel_result,     // description in LAGraph_Coarsen_Matching
+    GrB_Vector *inv_local_newlabel_result, // description in LAGraph_Coarsen_Matching
+
     // inputs:
-    LAGraph_Graph G,
-    LAGraph_Matching_kind matching_type,     // refer to above enum
-    bool preserve_mapping,                   // preserve initial namespace of nodes
-    bool combine_weights,                    // whether to sum edge weights or just keep the pattern
-    uint64_t seed,                           // used for matching
+    LAGraph_Graph G,                       // input graph
+    LAGraph_Matching_kind matching_type,   // how to perform the coarsening
+    bool preserve_mapping,                 // preserve original namespace of nodes
+    bool combine_weights,                  // whether to sum edge weights or just keep the pattern
+    uint64_t seed,                         // seed used for matching
     char *msg
 ) ;
 


### PR DESCRIPTION
* Rewrote parts of coarsening algorithm to reflect that there is only one coarsening step, and improved clarity of comments

### About the space optimization for the coarsening method:
In order to improve the space usage from O(n + e) to O(e), the following changes must occur:
(1) Do not compute a full vector of length num_nodes
(2) The node_parent vector must NOT have entries for singletons
(3) If preserve_mapping = false and we need to compute a compressed parent vector in Parent_to_S, then this compressed parent vector must NOT have entries for singletons

(2) can be done by examining the E matrix. In particular, singleton nodes will have empty rows in E. We can run a GrB_reduce on E and use the result as a mask to identify non-singleton nodes. Now, we can change the GrB_apply used to populate empty entries in node_parent to use this non-singleton mask as the input instead of a full vector.

(3) is trickier. Everything in the Parent_to_S function up until the GrB_extract can be kept as is. Up until this point, we have computed the compressed parent for all nodes that:
* Are preserved in the coarsened graph
* Are NOT singletons
Note that this intermediate result is also the new labels vector that tells us how preserved nodes are relabeled in the coarsened graph. In the space-optimized version, this new labels vector will NOT include new labels for singletons. The user must appropriately handle this. See the explanation below under "Potential easy solution to space optimization" for why this is OK.

The original purpose of the GrB_extract is to populate the compressed parents for discarded nodes (nodes that disappear in the coarsened graph). However, it only works because the parent vector passed as input into Parent_to_S is full, and we are OK with writing into all entries of the compressed parent vector. Neither of these are now true. In particular, the indices of the input parent vector can be partitioned into three parts:

* Indices that correspond to preserved, non-singleton nodes (we already have the compressed parents for these; they are their own parents) (present)
* Indices that correspond to discarded, non-singleton nodes (present)
* Indices that correspond to singleton nodes (empty)

Our goal is to populate the compressed parents for discarded, non-singleton nodes. A possible strategy is the following:
* Unpack the...
* WIP, this gets pretty ugly, see below instead.

---
_Potential easy solution to space optimization_: 
Eliminate singleton nodes upfront; we will build a new A matrix corresponding to the input graph without singleton nodes. This can be done by using a reduce_to_vector on the input matrix to identify singletons, then using the contents of that vector to GrB_extract from the input matrix into our singleton-free matrix. We will then run our coarsening as usual on this new matrix. We will have new outputs for the user to provide information about the singleton removal; see comments at the top of LAGraph_Coarsen_Matching for more details. 

**Note**: This approach involves a GrB_extract to pull rows/cols from the original A matrix, which seems to be very slow.