### PR TITLE
Fixed v1.1 build issues

### DIFF
--- a/experimental/benchmark/coarsen_matching_demo.c
+++ b/experimental/benchmark/coarsen_matching_demo.c
@@ -13,12 +13,24 @@
 
 // #define SHOW_RESULTS
 
+#define LG_FREE_ALL                     \
+{                                       \
+    LAGraph_Delete (&G, NULL) ;         \
+    GrB_free (&A) ;                     \
+    GrB_free (&coarsened) ;             \
+    GrB_free (&parent_result) ;         \
+    GrB_free (&newlabel_result) ;       \
+    GrB_free (&inv_newlabel_result) ;   \
+}                                       \
 
 int main(int argc, char **argv)
 {
     char msg [LAGRAPH_MSG_LEN] ;
 
     LAGraph_Graph G = NULL ;
+    GrB_Matrix A = NULL ;
+    GrB_Matrix coarsened = NULL ;
+    GrB_Vector parent_result = NULL, newlabel_result = NULL, inv_newlabel_result = NULL ;
 
     bool burble = false ; 
     demo_init (burble) ;
@@ -40,8 +52,6 @@ int main(int argc, char **argv)
         GrB_Index n = (argc > 2 ? atoi (argv [2]) : DEFAULT_SIZE) ;
         double density = (argc > 3 ? atof (argv [3]) : DEFAULT_DENSITY) ;
         uint64_t seed = (argc > 4 ? atoll (argv [4]) : DEFAULT_SEED) ;
-        
-        GrB_Matrix A = NULL ;
 
         LG_TRY (LAGraph_Random_Matrix (&A, GrB_FP64, n, n, density, seed, msg)) ;
         GRB_TRY (GrB_eWiseAdd (A, NULL, NULL, GrB_PLUS_FP64, A, A, GrB_DESC_T1)) ;
@@ -56,8 +66,6 @@ int main(int argc, char **argv)
     }
     GrB_Index n ;
     GRB_TRY (GrB_Matrix_nrows (&n, G->A)) ;
-    GrB_Matrix coarsened = NULL ;
-    GrB_Vector parent_result = NULL, newlabel_result = NULL, inv_newlabel_result = NULL ;
 
     int nt = NTHREAD_LIST ;
     
@@ -176,12 +184,8 @@ int main(int argc, char **argv)
 #endif
     }
 
-    //--------------------------------------------------------------------------
-    // free all workspace and finish
-    //--------------------------------------------------------------------------
     LG_FREE_ALL ;
 
     LG_TRY (LAGraph_Finalize (msg)) ;
     return (GrB_SUCCESS) ;
-
 }

--- a/experimental/test/include/LG_Xtest.h
+++ b/experimental/test/include/LG_Xtest.h
@@ -67,4 +67,18 @@ int LG_check_lcc
      char *msg
 ) ;
 
+int LG_check_coarsen
+(
+    // outputs:
+    GrB_Matrix *coarsened,    // coarsened adjacency
+    // inputs:
+    GrB_Matrix A,               // input adjacency (for the purposes of testing, is FP64)
+    GrB_Vector parent,          // parent mapping. Must not be NULL.
+    GrB_Vector newlabel,       // new labels of nodes, used to populate resulting adjacency matrix, can be NULL if preserve_mapping = 1, else must be a valid result
+    GrB_Vector inv_newlabel,   // inverse of newlabel, can be NULL if preserve_mapping = 1, else must be a valid result
+    int preserve_mapping,       // whether to preserve the original namespace of nodes
+    int combine_weights,        // whether to combine the weights of edges that collapse together
+    char *msg
+) ;
+
 #endif


### PR DESCRIPTION
@DrTimothyAldenDavis 
* Added LG_check_coarsen prototype to LG_Xtest.h
* Added LG_FREE_ALL macro definition to coarsen_matching_demo
* v1.1 should now build cleanly with no warnings/errors and pass all tests