### PR TITLE
minor build updates for LAGraph 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,10 @@
 cmake_minimum_required ( VERSION 3.20 ) # LAGraph can be built stand-alone
 
 # version of LAGraph
-set ( LAGraph_DATE "Dec 30, 2023" )
+set ( LAGraph_DATE "Jan 10, 2024" )
 set ( LAGraph_VERSION_MAJOR 1 CACHE STRING "" FORCE )
 set ( LAGraph_VERSION_MINOR 1 CACHE STRING "" FORCE )
-set ( LAGraph_VERSION_SUB   0 CACHE STRING "" FORCE )
+set ( LAGraph_VERSION_SUB   1 CACHE STRING "" FORCE )
 
 message ( STATUS "Building LAGraph version: v"
     ${LAGraph_VERSION_MAJOR}.
@@ -75,6 +75,9 @@ configure_file (
     "config/LAGraph.h.in"
     "${PROJECT_SOURCE_DIR}/include/LAGraph.h"
     NEWLINE_STYLE LF )
+
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
 
 #-------------------------------------------------------------------------------
 # code coverage and build type
@@ -167,7 +170,11 @@ if ( COVERAGE )
     message ( STATUS "OpenMP disabled for test coverage" )
 else ( )
     if ( LAGRAPH_USE_OPENMP )
-        find_package ( OpenMP GLOBAL )
+        if ( CMAKE_VERSION VERSION_LESS 3.24 )
+            find_package ( OpenMP COMPONENTS C )
+        else ( )
+            find_package ( OpenMP COMPONENTS C GLOBAL )
+        endif ( )
         if ( OpenMP_C_FOUND AND BUILD_STATIC_LIBS )
             list ( APPEND LAGRAPH_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
         endif ( )
@@ -354,7 +361,7 @@ install ( FILES
 
 if ( NOT MSVC )
     if ( BUILD_STATIC_LIBS )
-        if ( NOT WIN32 )
+        if ( NOT NO_LIBM )
             list ( APPEND LAGRAPH_STATIC_LIBS "m" )
         endif ( )
     endif ( )

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Jan 10, 2024: version 1.1.1
+
+    * minor update to build system
+
 Dec 30, 2023: version 1.1.0
 
     * major change to build system: by Markus Mützel

--- a/cmake_modules/SuiteSparsePolicy.cmake
+++ b/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,6 +248,19 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
+# Workaround for math.h on old macOS
+#-------------------------------------------------------------------------------
+
+if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+    # Older versions of math.h on the Mac define Real and Imag, which
+    # conflict with the internal use of those symbols in CHOLMOD, KLU, SPQR,
+    # UMFPACK, and ParU.
+    # This can be disabled with -D__NOEXTENSIONS__
+    message ( STATUS "MacOS: disable extensions in math.h" )
+    add_compile_definitions ( "__NOEXTENSIONS__" )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 

--- a/config/LAGraphConfig.cmake.in
+++ b/config/LAGraphConfig.cmake.in
@@ -53,7 +53,7 @@ endif ( )
 
 # Look for OpenMP
 if ( @LAGRAPH_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
-    find_dependency ( OpenMP )
+    find_dependency ( OpenMP COMPONENTS C )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
     endif ( )

--- a/include/LAGraph.h
+++ b/include/LAGraph.h
@@ -37,10 +37,10 @@
 // See also the LAGraph_Version utility method, which returns these values.
 // These definitions are derived from LAGraph/CMakeLists.txt.
 
-#define LAGRAPH_DATE "Dec 30, 2023"
+#define LAGRAPH_DATE "Jan 10, 2024"
 #define LAGRAPH_VERSION_MAJOR  1
 #define LAGRAPH_VERSION_MINOR  1
-#define LAGRAPH_VERSION_UPDATE 0
+#define LAGRAPH_VERSION_UPDATE 1
 
 //==============================================================================
 // include files and helper macros

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,12 +17,6 @@ include_directories ( utility )
 
 file ( GLOB LAGRAPH_LIB_SOURCES "utility/*.c" "algorithm/*.c" )
 
-if ( WIN32 )
-    set ( M_LIB "" )
-else ( )
-    set ( M_LIB "m" )
-endif ( )
-
 #-------------------------------------------------------------------------------
 # dynamic lagraph library properties
 #-------------------------------------------------------------------------------
@@ -42,7 +36,10 @@ if ( BUILD_SHARED_LIBS )
         set_target_properties ( LAGraph PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
-    target_link_libraries ( LAGraph PRIVATE GraphBLAS::GraphBLAS ${M_LIB} )
+    target_link_libraries ( LAGraph PRIVATE GraphBLAS::GraphBLAS )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( LAGraph PRIVATE "m" )
+    endif ( )
 
     target_include_directories ( LAGraph PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -80,7 +77,9 @@ if ( BUILD_STATIC_LIBS )
     else ( )
         target_link_libraries ( LAGraph_static PUBLIC GraphBLAS::GraphBLAS )
     endif ( )
-    target_link_libraries ( LAGraph_static PUBLIC ${M_LIB} )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( LAGraph_static PUBLIC "m" )
+    endif ( )
 
     target_include_directories ( LAGraph_static PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/benchmark/tc_demo.c
+++ b/src/benchmark/tc_demo.c
@@ -149,7 +149,7 @@ int main (int argc, char **argv)
     // warmup for more accurate timing, and also print # of triangles
     double ttot = LAGraph_WallClockTime ( ) ;
     printf ("\nwarmup method: ") ;
-    int presort = LAGr_TriangleCount_AutoSort ; // = 0 (auto selection)
+    LAGr_TriangleCount_Presort presort = LAGr_TriangleCount_AutoSort ;
     print_method (stdout, 6, presort) ;
 
     // warmup method:


### PR DESCRIPTION
Changes in this pending release (v1.1.1):

updates to build system:

- find_package for OpenMP looks for C components only, and uses the GLOBAL keyword only for cmake 3.24 or later.
- `libm` linked in via cmake `CheckSymbolExists`
- workaround for a very old MacOS case (math.h includes some breaking extensions, powerpc only)

update to benchmarks:  using the proper enum type in the triangle-count test.

This version will appear in SuiteSparse 7.5.0.
