### PR TITLE
Fix spell mistake in hello_world demo sources

### DIFF
--- a/experimental/benchmark/helloworld2_demo.c
+++ b/experimental/benchmark/helloworld2_demo.c
@@ -25,8 +25,8 @@
 //
 // Then run this demo with an input matrix.  For example:
 //
-//      ./experimental/benchmark/hellworld2_demo < ../data/west0067.mtx
-//      ./experimental/benchmark/hellworld2_demo < ../data/karate.mtx
+//      ./experimental/benchmark/helloworld2_demo < ../data/west0067.mtx
+//      ./experimental/benchmark/helloworld2_demo < ../data/karate.mtx
 //
 // If you create your own algorithm and want to mimic this main program, call
 // it write in experimental/benchmark/whatever_demo.c (with "_demo.c" as the

--- a/experimental/benchmark/helloworld_demo.c
+++ b/experimental/benchmark/helloworld_demo.c
@@ -25,9 +25,9 @@
 //
 // Then run this demo with an input matrix.  For example:
 //
-//      ./experimental/benchmark/hellworld_demo ../data/west0067.mtx
-//      ./experimental/benchmark/hellworld_demo < ../data/west0067.mtx
-//      ./experimental/benchmark/hellworld_demo ../data/karate.mtx
+//      ./experimental/benchmark/helloworld_demo ../data/west0067.mtx
+//      ./experimental/benchmark/helloworld_demo < ../data/west0067.mtx
+//      ./experimental/benchmark/helloworld_demo ../data/karate.mtx
 //
 // If you create your own algorithm and want to mimic this main program, call
 // it write in experimental/benchmark/whatever_demo.c (with "_demo.c" as the


### PR DESCRIPTION
In description written:
```c
// Then run this demo with an input matrix.  For example:
//
//      ./experimental/benchmark/hellworld_demo ../data/west0067.mtx
//      ./experimental/benchmark/hellworld_demo < ../data/west0067.mtx
//      ./experimental/benchmark/hellworld_demo ../data/karate.mtx
```

Where the word `Hello` is spelled `hell`
```bash
~/LAGraph/build stable ❯ ls experimental/benchmark/ | grep hell                                                                       03:34:38 PM
helloworld2_demo
helloworld_demo
```