### PR TITLE
CI: update version of macos image and action upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
-name: LAGraph CI
+name: LAGraph CI with Builtin GraphBLAS
 
 on:
   workflow_dispatch:
   push:
     branches-ignore:
-      - '**/v1.2*'
       - '**/*dev2'
   pull_request:
 
@@ -14,54 +13,49 @@ jobs:
     strategy:
       matrix:
         config:
-         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 0, deploy_test_results: true}
-         - {grb_version: 7.4.4, conda_grb_package_hash: hcb278e6, conda_extension: conda, vanilla: 1, deploy_test_results: false}
+        # if there are multiple items in this list, only use should
+        # deployit=true for just one of them.
+         - {grb_version: 9.3.1, deployit: true}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - name: Install tools for build
       run: |
         sudo apt install -y lcov
-    - name: Get GraphBLAS binaries
+    - name: Build GraphBLAS
       run: |
-        mkdir graphblas-binaries
-        cd graphblas-binaries
-        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/linux-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-        if [ ${{ matrix.config.conda_extension }} == "tar.bz2" ]; then
-          tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-        else
-          unzip graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-          tar xf pkg-graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.zst
-        fi
+        git clone https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+        cd GraphBLAS
+        git checkout tags/v${{ matrix.config.grb_version }}
+        make compact
+        sudo make install
         cd ..
     - name: Build project
       run: |
-        export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
-        export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.so
+        export GRAPHBLAS_INCLUDE_DIR=`pwd`/GraphBLAS/include/suitesparse
+        export GRAPHBLAS_LIBRARY=`pwd`/GraphBLAS/lib/libgraphblas.so
         cd build
-        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
+        cmake .. -DCOVERAGE=1 -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
         JOBS=2 make
         make test_coverage
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: matrix.deploy_test_results && github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      if: matrix.config.deployit && github.event_name == 'push' && github.ref == 'refs/heads/stable'
       with:
         branch: gh-pages
         folder: build/test_coverage/
         single-commit: true
     - name: Save output
-      uses: actions/upload-artifact@v2.2.3
+      uses: actions/upload-artifact@v4.6.0
       with:
         name: test_coverage
         path: build/test_coverage/
-      if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
   macos:
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       matrix:
         config:
-         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 0}
-         - {grb_version: 7.4.4, conda_grb_package_hash: ha894c9a, conda_extension: conda, vanilla: 1}
+         - {grb_version: 9.3.1}
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
@@ -70,25 +64,21 @@ jobs:
         brew tap-new libomp/cask
         brew extract --version=14.0.6 libomp libomp/cask
         brew install libomp@14.0.6
-    - name: Get GraphBLAS binaries
+    - name: Build GraphBLAS
       run: |
-        mkdir graphblas-binaries
-        cd graphblas-binaries
-        wget --quiet https://anaconda.org/conda-forge/graphblas/${{ matrix.config.grb_version }}/download/osx-64/graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-        if [ ${{ matrix.config.conda_extension }} == "tar.bz2" ]; then
-          tar xf graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-        else
-          unzip graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.${{ matrix.config.conda_extension }}
-          tar xf pkg-graphblas-${{ matrix.config.grb_version }}-${{ matrix.config.conda_grb_package_hash }}_0.tar.zst
-        fi
+        git clone https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+        cd GraphBLAS
+        git checkout tags/v${{ matrix.config.grb_version }}
+        make compact
+        sudo make install
         cd ..
     - name: Build project
       run: |
-        export GRAPHBLAS_INCLUDE_DIR=`pwd`/graphblas-binaries/include
-        export GRAPHBLAS_LIBRARY=`pwd`/graphblas-binaries/lib/libgraphblas.dylib
+        export GRAPHBLAS_INCLUDE_DIR=`pwd`/GraphBLAS/include/suitesparse
+        export GRAPHBLAS_LIBRARY=`pwd`/GraphBLAS/lib/libgraphblas.dylib
         # adding an extra line to the CMakeLists.txt file to locate the libomp instance installed by brew
         echo 'include_directories("/usr/local/opt/libomp/include")' | cat - CMakeLists.txt
         cd build
-        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY} -DLAGRAPH_VANILLA=${{ matrix.config.vanilla }}
+        CC=gcc cmake .. -DGRAPHBLAS_INCLUDE_DIR=${GRAPHBLAS_INCLUDE_DIR} -DGRAPHBLAS_LIBRARY=${GRAPHBLAS_LIBRARY}
         JOBS=2 make
         make test


### PR DESCRIPTION
Hello,

I noticed that the CI configuration for the v1.2 branch hasn’t been updated for the past two years. I also observed that the new CI setup for the stable branch (https://github.com/GraphBLAS/LAGraph/pull/266) seems like it would be a great fit for v1.2.

You can review the successful CI run for the latest commit on the v1.2 branch here:
https://github.com/SparseLinearAlgebra/LAGraph/actions
https://github.com/SparseLinearAlgebra/LAGraph/commits/refs/heads/v1.2_CI/
Also in the current PR

With that in mind, would you be open to updating the CI file for v1.2, or is there a specific reason for maintaining its current setup?

Thank you.