### PR TITLE
Fix regular path query test coverage

### DIFF
--- a/data/rpq_data/3_a.mtx
+++ b/data/rpq_data/3_a.mtx
@@ -1,4 +1,4 @@
-%%MatrixMarket matrix coordinate pattern general
+%%MatrixMarket matrix coordinate pattern symmetric
 %%GraphBLAS type bool
 2 2 1
 1 1

--- a/data/rpq_data/3_b.mtx
+++ b/data/rpq_data/3_b.mtx
@@ -1,4 +1,4 @@
-%%MatrixMarket matrix coordinate pattern general
+%%MatrixMarket matrix coordinate pattern symmetric
 %%GraphBLAS type bool
 2 2 1
 1 1

--- a/experimental/algorithm/LAGraph_RegularPathQuery.c
+++ b/experimental/algorithm/LAGraph_RegularPathQuery.c
@@ -75,9 +75,6 @@
 // Performance considerations: the best performance is shown when the algorithm
 // receives a minimal deterministic finite automaton as an input.
 
-// FIXME: some of the code below is not covered by the test suite, "make cov".
-// See the FIXMEs below.
-
 #define LG_FREE_WORK                            \
 {                                               \
     GrB_free (&frontier) ;                      \
@@ -200,8 +197,6 @@ int LAGraph_RegularPathQuery
         B[i] = R[i]->A ;
         if (R[i]->is_symmetric_structure == LAGraph_TRUE)
         {
-            // FIXME: this case is not tested
-            // by experimental/test/test_RegularPathQuery.c
             BT[i] = B[i] ;
         }
         else
@@ -326,8 +321,6 @@ int LAGraph_RegularPathQuery
             }
             else
             {
-                // FIXME: this case is not tested
-                // by experimental/test/test_RegularPathQuery.c
                 GRB_TRY (GrB_mxm (symbol_frontier, GrB_NULL, GrB_NULL,
                     GrB_LOR_LAND_SEMIRING_BOOL, B[i], frontier, GrB_DESC_RT0)) ;
             }

--- a/experimental/test/test_RegularPathQuery.c
+++ b/experimental/test/test_RegularPathQuery.c
@@ -70,143 +70,152 @@ void test_RegularPathQueryBasic (void)
         snprintf (testcase_name, LEN, "basic regular path query %s", files[k].name) ;
         TEST_CASE (testcase_name) ;
 
-        // Load graph from MTX files representing its adjacency matrix
-        // decomposition
-        for (int i = 0 ; ; i++)
+        for (int check_symmetry = 0 ; check_symmetry <= 1 ; check_symmetry++)
         {
-            const char *name = files[k].graphs[i] ;
+            // Load graph from MTX files representing its adjacency matrix
+            // decomposition
+            for (int i = 0 ; ; i++)
+            {
+                const char *name = files[k].graphs[i] ;
 
-            if (name == NULL) break ;
-            if (strlen(name) == 0) continue ;
+                if (name == NULL) break ;
+                if (strlen(name) == 0) continue ;
 
+                snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+                FILE *f = fopen (filename, "r") ;
+                TEST_CHECK (f != NULL) ;
+                OK (LAGraph_MMRead (&A, f, msg)) ;
+                OK (fclose (f));
+
+                OK (LAGraph_New (&(G[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
+
+                TEST_CHECK (A == NULL) ;
+            }
+
+            // Load NFA from MTX files representing its adjacency matrix
+            // decomposition
+            for (int i = 0 ; ; i++)
+            {
+                const char *name = files[k].fas[i] ;
+
+                if (name == NULL) break ;
+                if (strlen(name) == 0) continue ;
+
+                snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+                FILE *f = fopen (filename, "r") ;
+                TEST_CHECK (f != NULL) ;
+                OK (LAGraph_MMRead (&A, f, msg)) ;
+                OK (fclose (f)) ;
+
+                OK (LAGraph_New (&(R[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
+
+                if (check_symmetry)
+                {
+                    // Check if the pattern is symmetric - if it isn't make it.
+                    // Note this also computes R[i]->AT
+                    OK (LAGraph_Cached_IsSymmetricStructure (R[i], msg)) ;
+                }
+
+                TEST_CHECK (A == NULL) ;
+            }
+
+            // Note the matrix rows/cols are enumerated from 0 to n-1.
+            // Meanwhile, in MTX format they are enumerated from 1 to n. Thus,
+            // when loading/comparing the results these values should be
+            // decremented/incremented correspondingly.
+
+            // Load graph source nodes from the sources file
+            GrB_Index s ;
+            GrB_Index S[16] ;
+            size_t ns = 0 ;
+
+            const char *name = files[k].sources ;
             snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
             FILE *f = fopen (filename, "r") ;
             TEST_CHECK (f != NULL) ;
-            OK (LAGraph_MMRead (&A, f, msg)) ;
-            OK (fclose (f));
 
-            OK (LAGraph_New (&(G[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
+            while (fscanf(f, "%" PRIu64, &s) != EOF)
+            {
+                S[ns++] = s - 1 ;
+            }
 
-            TEST_CHECK (A == NULL) ;
-        }
+            OK (fclose(f)) ;
 
-        // Load NFA from MTX files representing its adjacency matrix
-        // decomposition
-        for (int i = 0 ; ; i++)
-        {
-            const char *name = files[k].fas[i] ;
+            // Load NFA starting states from the meta file
+            GrB_Index qs ;
+            GrB_Index QS[16] ;
+            size_t nqs = 0 ;
 
-            if (name == NULL) break ;
-            if (strlen(name) == 0) continue ;
-
+            name = files[k].fa_meta ;
             snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
-            FILE *f = fopen (filename, "r") ;
+            f = fopen (filename, "r") ;
             TEST_CHECK (f != NULL) ;
-            OK (LAGraph_MMRead (&A, f, msg)) ;
-            OK (fclose (f)) ;
 
-            OK (LAGraph_New (&(R[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
-            OK (LAGraph_Cached_AT (R[i], msg)) ;
+            uint64_t nqs64 = 0 ;
+            TEST_CHECK (fscanf(f, "%" PRIu64, &nqs64) != EOF) ;
+            nqs = (size_t) nqs64 ;
 
-            TEST_CHECK (A == NULL) ;
-        }
+            for (uint64_t i = 0; i < nqs; i++) {
+                TEST_CHECK (fscanf(f, "%" PRIu64, &qs) != EOF) ;
+                QS[i] = qs - 1 ;
+            }
 
-        // Note the matrix rows/cols are enumerated from 0 to n-1. Meanwhile, in
-        // MTX format they are enumerated from 1 to n. Thus, when
-        // loading/comparing the results these values should be
-        // decremented/incremented correspondingly.
+            // Load NFA final states from the same file
+            uint64_t qf ;
+            uint64_t QF[16] ;
+            size_t nqf = 0 ;
+            uint64_t  nqf64 = 0 ;
 
-        // Load graph source nodes from the sources file
-        GrB_Index s ;
-        GrB_Index S[16] ;
-        size_t ns = 0 ;
+            TEST_CHECK (fscanf(f, "%" PRIu64, &nqf64) != EOF) ;
+            nqf = (size_t) nqf64 ;
 
-        const char *name = files[k].sources ;
-        snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
-        FILE *f = fopen (filename, "r") ;
-        TEST_CHECK (f != NULL) ;
+            for (uint64_t i = 0; i < nqf; i++) {
+                TEST_CHECK (fscanf(f, "%" PRIu64, &qf) != EOF) ;
+                QF[i] = qf - 1 ;
+            }
 
-        while (fscanf(f, "%" PRIu64, &s) != EOF)
-        {
-            S[ns++] = s - 1 ;
-        }
+            OK (fclose(f)) ;
 
-        OK (fclose(f)) ;
+            // Evaluate the algorithm
+            GrB_Vector r = NULL ;
 
-        // Load NFA starting states from the meta file
-        GrB_Index qs ;
-        GrB_Index QS[16] ;
-        size_t nqs = 0 ;
+            OK (LAGraph_RegularPathQuery (&r, R, MAX_LABELS, QS, nqs,
+                                             QF, nqf, G, S, ns, msg)) ;
 
-        name = files[k].fa_meta ;
-        snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
-        f = fopen (filename, "r") ;
-        TEST_CHECK (f != NULL) ;
+            // Extract results from the output vector
+            GrB_Index *reachable ;
+            bool *values ;
 
-        uint64_t nqs64 = 0 ;
-        TEST_CHECK (fscanf(f, "%" PRIu64, &nqs64) != EOF) ;
-        nqs = (size_t) nqs64 ;
+            GrB_Index nvals ;
+            GrB_Vector_nvals (&nvals, r) ;
 
-        for (uint64_t i = 0; i < nqs; i++) {
-            TEST_CHECK (fscanf(f, "%" PRIu64, &qs) != EOF) ;
-            QS[i] = qs - 1 ;
-        }
+            OK (LAGraph_Malloc ((void **) &reachable, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
+            OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
 
-        // Load NFA final states from the same file
-        uint64_t qf ;
-        uint64_t QF[16] ;
-        size_t nqf = 0 ;
-        uint64_t  nqf64 = 0 ;
+            GrB_Vector_extractTuples (reachable, values, &nvals, r) ;
 
-        TEST_CHECK (fscanf(f, "%" PRIu64, &nqf64) != EOF) ;
-        nqf = (size_t) nqf64 ;
+            // Compare the results with expected values
+            TEST_CHECK (nvals == files[k].expected_count) ;
+            for (uint64_t i = 0 ; i < nvals ; i++)
+                TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
 
-        for (uint64_t i = 0; i < nqf; i++) {
-            TEST_CHECK (fscanf(f, "%" PRIu64, &qf) != EOF) ;
-            QF[i] = qf - 1 ;
-        }
+            // Cleanup
+            OK (LAGraph_Free ((void **) &values, NULL)) ;
+            OK (LAGraph_Free ((void **) &reachable, NULL)) ;
 
-        OK (fclose(f)) ;
+            OK (GrB_free (&r)) ;
 
-        // Evaluate the algorithm
-        GrB_Vector r = NULL ;
+            for (uint64_t i = 0 ; i < MAX_LABELS ; i++)
+            {
+                if (G[i] == NULL) continue ;
+                OK (LAGraph_Delete (&(G[i]), msg)) ;
+            }
 
-        OK (LAGraph_RegularPathQuery (&r, R, MAX_LABELS, QS, nqs,
-                                         QF, nqf, G, S, ns, msg)) ;
-
-        // Extract results from the output vector
-        GrB_Index *reachable ;
-        bool *values ;
-
-        GrB_Index nvals ;
-        GrB_Vector_nvals (&nvals, r) ;
-
-        OK (LAGraph_Malloc ((void **) &reachable, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
-        OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
-
-        GrB_Vector_extractTuples (reachable, values, &nvals, r) ;
-
-        // Compare the results with expected values
-        TEST_CHECK (nvals == files[k].expected_count) ;
-        for (uint64_t i = 0 ; i < nvals ; i++)
-            TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
-
-        // Cleanup
-        OK (LAGraph_Free ((void **) &values, NULL)) ;
-        OK (LAGraph_Free ((void **) &reachable, NULL)) ;
-
-        OK (GrB_free (&r)) ;
-
-        for (uint64_t i = 0 ; i < MAX_LABELS ; i++)
-        {
-            if (G[i] == NULL) continue ;
-            OK (LAGraph_Delete (&(G[i]), msg)) ;
-        }
-
-        for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
-        {
-            if (R[i] == NULL) continue ;
-            OK (LAGraph_Delete (&(R[i]), msg)) ;
+            for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
+            {
+                if (R[i] == NULL) continue ;
+                OK (LAGraph_Delete (&(R[i]), msg)) ;
+            }
         }
     }
 


### PR DESCRIPTION
In #261 an algorithm for evaluating regular path queries has been introduced. The algorithm uses NFAs for representing regular constraints and uses transpositions of their adjacency matrices. The implementation involved checks on whether the provided adjacency matrix is symmetric and its transpositions are cached though this behavior hasn't been tested and the coverage has been lower than 100%. This patch fixes it by varying whether to cache the matrix transpositions and compute the symmetry flags.