### PR TITLE
SCC Global Removal and testing

### DIFF
--- a/experimental/algorithm/LAGraph_scc.c
+++ b/experimental/algorithm/LAGraph_scc.c
@@ -151,7 +151,9 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
     GrB_free (&inf);                        \
     GrB_free (&f);                          \
     GrB_free (&b);                          \
+    GrB_free (&D);                          \
     GrB_free (&mask);                       \
+    GrB_free (&m2);                         \
     GrB_free (&FW);                         \
     GrB_free (&BW);                         \
     GrB_free (&sel1);                       \
@@ -175,14 +177,17 @@ int LAGraph_scc
     sccContext contx = {NULL, NULL, NULL};
     GrB_Info info = GrB_SUCCESS;
     GrB_Type contx_type = NULL;
+    GrB_Type type_F = NULL, type_B = NULL, type_M = NULL;
+    int hand_F = GrB_DEFAULT, hand_B = GrB_DEFAULT, hand_M = GrB_DEFAULT;
+    uint64_t n_F = 0, n_B = 0, n_M = 0, size_F = 0, size_B = 0, size_M = 0;
     GrB_Vector scc = NULL ;
     GrB_Vector ind = NULL ;
     GrB_Vector inf = NULL ;
     GrB_Vector x = NULL ;
-    GrB_Vector f = NULL, b = NULL, mask = NULL ;
+    GrB_Vector f = NULL, b = NULL, mask = NULL, m2 = NULL;
     GrB_IndexUnaryOp sel1 = NULL, sel2 = NULL ;
     GrB_Monoid Add = NULL ;
-    GrB_Matrix FW = NULL, BW = NULL;
+    GrB_Matrix FW = NULL, BW = NULL, D = NULL;
     LG_ASSERT(result != NULL, GrB_NULL_POINTER);
     LG_ASSERT(A != NULL, GrB_NULL_POINTER);
 
@@ -214,6 +219,7 @@ int LAGraph_scc
     GRB_TRY (GrB_Vector_new (&f, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&b, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&mask, GrB_BOOL, n));
+    GRB_TRY (GrB_Vector_new (&m2, GrB_BOOL, n));
     GRB_TRY (GrB_Vector_new (&x, GrB_BOOL, n));
     GRB_TRY (GxB_Type_new (
         &contx_type, sizeof(sccContext), "sccContext", SCCCONTEXT)) ;
@@ -236,7 +242,7 @@ int LAGraph_scc
     GRB_TRY (GrB_Matrix_assign_BOOL(
         FW, A, NULL, true, GrB_ALL, n, GrB_ALL, n, GrB_DESC_S)) ;
     GRB_TRY (GrB_transpose (BW, 0, 0, FW, 0));     // BW = FW'
-
+       
     // check format
     int32_t A_format, AT_format;
     GRB_TRY (GrB_get (FW, &A_format , GrB_STORAGE_ORIENTATION_HINT));
@@ -246,9 +252,9 @@ int LAGraph_scc
     LG_ASSERT (is_csr, GrB_INVALID_VALUE) ;
 
     // remove trivial SCCs
-    GRB_TRY (GrB_reduce (f, 0, GrB_PLUS_UINT64, GrB_PLUS_UINT64, FW, 0));
-    GRB_TRY (GrB_reduce (b, 0, GrB_PLUS_UINT64, GrB_PLUS_UINT64, BW, 0));
-    GRB_TRY (GrB_eWiseMult (mask, NULL, NULL, GrB_ONEB_BOOL, f, b, NULL));
+    GRB_TRY (GrB_Vector_assign_BOOL (x, NULL, NULL, 0, GrB_ALL, n, NULL)) ;
+    GRB_TRY (GrB_mxv (m2, NULL, NULL, GxB_ANY_PAIR_BOOL, FW, x, NULL)) ;
+    GRB_TRY (GrB_mxv (mask, m2, NULL, GxB_ANY_PAIR_BOOL, BW, x, GrB_DESC_S)) ;
     GRB_TRY (GrB_Vector_nvals (&nvals, mask));
 
     GRB_TRY (GrB_assign (scc, 0, 0, ind, GrB_ALL, 0, 0));
@@ -256,6 +262,7 @@ int LAGraph_scc
 
     if (nvals < n)
     {
+        // GRB_TRY (GrB_Matrix_diag(&D, mask, 0)) ;
         // TODO this should be a single mxm with a diagonal mask matrix.
         // No reason for context. 
         GRB_TRY (GrB_Vector_extractTuples (NULL, contx.F, &n, scc));
@@ -263,6 +270,7 @@ int LAGraph_scc
             FW, NULL, NULL, sel1, FW, &contx, NULL)) ;
         GRB_TRY (GrB_Matrix_select_UDT (
             BW, NULL, NULL, sel1, BW, &contx, NULL)) ;
+        // GRB_TRY (GrB_free(&D)) ;
     }
 
     GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
@@ -281,16 +289,33 @@ int LAGraph_scc
 
         GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, b, 0));
         GRB_TRY (GrB_assign (scc, mask, GrB_MIN_UINT64, f, GrB_ALL, 0, 0));
-
-        GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.F, &n, f));
-        GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.B, &n, b));
-        GRB_TRY (GrB_Vector_extractTuples_BOOL (NULL, contx.M, &n, mask));
+        #if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
+            GRB_TRY(GxB_Vector_unload(
+                f, (void **) &contx.F, &type_F, &n_F, &size_F, &hand_F, NULL)) ;
+            GRB_TRY(GxB_Vector_unload(
+                b, (void **) &contx.B, &type_B, &n_B, &size_B, &hand_B, NULL)) ;
+            GRB_TRY(GxB_Vector_unload(
+                mask, (void **) &contx.M, &type_M, &n_M, &size_M, &hand_M, NULL
+            )) ;
+        #else
+            GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.F, &n, f));
+            GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.B, &n, b));
+            GRB_TRY (GrB_Vector_extractTuples_BOOL (NULL, contx.M, &n, mask));
+        #endif
 
         GRB_TRY (GrB_Matrix_select_UDT (
             FW, NULL, NULL, sel2, FW, &contx, NULL)) ;
         GRB_TRY (GrB_Matrix_select_UDT (
             BW, NULL, NULL, sel2, BW, &contx, NULL)) ;
-
+        #if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
+            GRB_TRY(GxB_Vector_load(
+                f, (void **) &contx.F, type_F, n_F, size_F, hand_F, NULL)) ;
+            GRB_TRY(GxB_Vector_load(
+                b, (void **) &contx.B, type_B, n_B, size_B, hand_B, NULL)) ;
+            GRB_TRY(GxB_Vector_load(
+                mask, (void **) &contx.M, type_M, n_M, size_M, hand_M, NULL
+            )) ;
+        #endif
         GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
     }
     GRB_TRY (GrB_Vector_apply_BinaryOp2nd_UINT64 (

--- a/experimental/algorithm/LAGraph_scc.c
+++ b/experimental/algorithm/LAGraph_scc.c
@@ -34,8 +34,19 @@
 #if LAGRAPH_SUITESPARSE
 
 //****************************************************************************
-// global C arrays used in SelectOp
-GrB_Index *I = NULL, *V = NULL, *F = NULL, *B = NULL, *M = NULL;
+//arrays used in SelectOp
+typedef struct 
+{
+    uint64_t *F, *B;
+    bool *M;
+} sccContext;
+#define SCCCONTEXT \
+"typedef struct \n"             \
+"{\n"                           \
+"    uint64_t *F, *B;\n"    \
+"    bool *M;\n"                \
+"} sccContext;\n"               
+
 
 // edge_removal:
 //  - remove the edges connected to newly identified SCCs (vertices u with M[u]==1)
@@ -50,11 +61,21 @@ GrB_Index *I = NULL, *V = NULL, *F = NULL, *B = NULL, *M = NULL;
 // an edge (u, v) if either F[u]!=F[v] or B[u]!=B[v] holds, which can accelerate
 // the SCC computation in the future rounds.
 
-void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk) ;
-void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
+void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk) ;
+void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk)
 {
-    (*z) = (!M[i] && !M[j] && F[i] == F[j] && B[i] == B[j]) ;
+    (*z) = (!thunk->M[i] && !thunk->M[j] 
+        && thunk->F[i] == thunk->F[j] 
+        && thunk->B[i] == thunk->B[j]) ;
 }
+#define EDGE_REMOVAL \
+"void edge_removal \n"                                                          \
+"(bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk)\n" \
+"{\n"                                                                           \
+"    (*z) = (!thunk->M[i] && !thunk->M[j] \n"                                   \
+"        && thunk->F[i] == thunk->F[j] \n"                                      \
+"        && thunk->B[i] == thunk->B[j]) ;\n"                                    \
+"}\n"                                                                           
 
 //****************************************************************************
 // trim_one: remove the edges connected to trivial SCCs
@@ -62,11 +83,17 @@ void edge_removal (bool *z, const void *x, GrB_Index i, GrB_Index j, const void 
 //  - M[i] = i   | if vertex i is a trivial SCC
 //    M[i] = n   | otherwise
 
-void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk) ;
-void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const void *thunk)
+void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk) ;
+void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk)
 {
-    (*z) = (M[i] == M[j]) ;
+    (*z) = (thunk->F[i] == thunk->F[j]) ;
 }
+#define TRIM_ONE \
+"void trim_one\n"                                                               \
+"(bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContext *thunk)\n" \
+"{\n"                                                                           \
+"    (*z) = (thunk->F[i] == thunk->F[j]) ;\n"                                   \
+"}\n"
 
 //****************************************************************************
 // label propagation
@@ -91,14 +118,17 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
     GRB_TRY (GrB_Vector_new (&s, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&t, GrB_UINT64, n));
     GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
+    // GxB_fprint(s, GxB_SHORT, stdout);
     GRB_TRY (GrB_assign (t, 0, 0, label, GrB_ALL, 0, 0));
 
     GrB_Index active;
     while (true)
     {
+        // GRB_TRY (GrB_mxv 
+        //     (t, 0, GrB_MIN_UINT64, GrB_MIN_SECOND_SEMIRING_UINT64, AT, s, 0));
         GRB_TRY (GrB_vxm (t, 0, GrB_MIN_UINT64,
                                  GrB_MIN_FIRST_SEMIRING_UINT64, s, A, 0));
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISNE_UINT64, t, label, 0));
+        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_NE_UINT64, t, label, 0));
         GRB_TRY (GrB_assign (label, mask, 0, t, GrB_ALL, 0, 0));
         GRB_TRY (GrB_reduce (&active, 0, GrB_PLUS_MONOID_UINT64, mask, 0));
         if (active == 0) break;
@@ -114,11 +144,9 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
 
 #undef  LG_FREE_ALL
 #define LG_FREE_ALL                         \
-    LAGraph_Free ((void **) &I, msg);       \
-    LAGraph_Free ((void **) &V, msg);       \
-    LAGraph_Free ((void **) &F, msg);       \
-    LAGraph_Free ((void **) &B, msg);       \
-    LAGraph_Free ((void **) &M, msg);       \
+    LAGraph_Free ((void **) &contx.F, msg);       \
+    LAGraph_Free ((void **) &contx.B, msg);       \
+    LAGraph_Free ((void **) &contx.M, msg);       \
     GrB_free (&ind);                        \
     GrB_free (&inf);                        \
     GrB_free (&f);                          \
@@ -128,6 +156,7 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
     GrB_free (&BW);                         \
     GrB_free (&sel1);                       \
     GrB_free (&sel2);                       \
+    GrB_free (&contx_type);                 \
     GrB_free (&scc);
 
 #endif
@@ -143,28 +172,70 @@ int LAGraph_scc
 #if LAGRAPH_SUITESPARSE
 
     LG_CLEAR_MSG ;
-
-    GrB_Info info;
+    sccContext contx = {NULL, NULL, NULL};
+    GrB_Info info = GrB_SUCCESS;
+    GrB_Type contx_type = NULL;
     GrB_Vector scc = NULL ;
     GrB_Vector ind = NULL ;
     GrB_Vector inf = NULL ;
+    GrB_Vector x = NULL ;
     GrB_Vector f = NULL, b = NULL, mask = NULL ;
     GrB_IndexUnaryOp sel1 = NULL, sel2 = NULL ;
     GrB_Monoid Add = NULL ;
     GrB_Matrix FW = NULL, BW = NULL;
-
-    if (result == NULL || A == NULL) return (GrB_NULL_POINTER) ;
+    LG_ASSERT(result != NULL, GrB_NULL_POINTER);
+    LG_ASSERT(A != NULL, GrB_NULL_POINTER);
 
     GrB_Index n, ncols, nvals;
     GRB_TRY (GrB_Matrix_nrows (&n, A));
     GRB_TRY (GrB_Matrix_ncols (&ncols, A));
-    if (n != ncols) return (GrB_DIMENSION_MISMATCH) ;
+    LG_ASSERT(n == ncols, GrB_DIMENSION_MISMATCH);
+    
+
+    LG_TRY (LAGraph_Malloc ((void **) &contx.F, n, sizeof (uint64_t), msg)) ;
+    LG_TRY (LAGraph_Malloc ((void **) &contx.B, n, sizeof (uint64_t), msg)) ;
+    LG_TRY (LAGraph_Malloc ((void **) &contx.M, n, sizeof (bool), msg)) ;
+    // LG_TRY (LAGraph_Malloc (&contx.data, 3 * n, sizeof (uint64_t), msg)) ;
+    // contx.F = (uint64_t *) contx.data;
+    // contx.B = (contx.F) + n;
+    // contx.M = (contx.F) + 2 * n;
+    // scc: the SCC identifier for each vertex
+    // scc[u] == n: not assigned yet
+    GRB_TRY (GrB_Vector_new (&scc, GrB_UINT64, n));
+    // vector of indices: ind[i] == i
+    GRB_TRY (GrB_Vector_new (&ind, GrB_UINT64, n));
+    GRB_TRY (GrB_Vector_assign_UINT64 (ind, NULL, NULL, 0, GrB_ALL, n, NULL)) ;
+    GRB_TRY (GrB_Vector_apply_IndexOp_UINT64 (
+        ind, NULL, NULL, GrB_ROWINDEX_INT64, ind, 0, NULL)) ;
+    // vector of infinite value: inf[i] == n
+    GRB_TRY (GrB_Vector_new (&inf, GrB_UINT64, n));
+    GRB_TRY (GrB_assign (inf, 0, 0, n, GrB_ALL, 0, 0));
+    // other vectors
+    GRB_TRY (GrB_Vector_new (&f, GrB_UINT64, n));
+    GRB_TRY (GrB_Vector_new (&b, GrB_UINT64, n));
+    GRB_TRY (GrB_Vector_new (&mask, GrB_BOOL, n));
+    GRB_TRY (GrB_Vector_new (&x, GrB_BOOL, n));
+    GRB_TRY (GxB_Type_new (
+        &contx_type, sizeof(sccContext), "sccContext", SCCCONTEXT)) ;
+    GRB_TRY (GxB_IndexUnaryOp_new (
+        &sel1, (GxB_index_unary_function) trim_one, 
+        GrB_BOOL, GrB_UINT64, contx_type, 
+        // NULL, NULL
+        "trim_one", TRIM_ONE
+    ));
+    GRB_TRY (GxB_IndexUnaryOp_new (
+        &sel2, (GxB_index_unary_function) edge_removal, 
+        GrB_BOOL, GrB_UINT64, contx_type,
+        // NULL, NULL
+        "edge_removal", EDGE_REMOVAL
+    ));
 
     // store the graph in both directions (forward / backward)
     GRB_TRY (GrB_Matrix_new (&FW, GrB_BOOL, n, n));
     GRB_TRY (GrB_Matrix_new (&BW, GrB_BOOL, n, n));
-    GRB_TRY (GrB_transpose (FW, 0, 0, A, GrB_DESC_T0)); // FW = A
-    GRB_TRY (GrB_transpose (BW, 0, 0, A, 0));     // BW = A'
+    GRB_TRY (GrB_Matrix_assign_BOOL(
+        FW, A, NULL, true, GrB_ALL, n, GrB_ALL, n, GrB_DESC_S)) ;
+    GRB_TRY (GrB_transpose (BW, 0, 0, FW, 0));     // BW = FW'
 
     // check format
     int32_t A_format, AT_format;
@@ -172,79 +243,59 @@ int LAGraph_scc
     GRB_TRY (GrB_get (BW, &AT_format, GrB_STORAGE_ORIENTATION_HINT));
 
     bool is_csr = (A_format == GrB_ROWMAJOR && AT_format == GrB_ROWMAJOR);
-    if (!is_csr) return (GrB_INVALID_VALUE) ;
-
-    LG_TRY (LAGraph_Malloc ((void **) &I, n, sizeof (GrB_Index), msg)) ;
-    LG_TRY (LAGraph_Malloc ((void **) &V, n, sizeof (GrB_Index), msg)) ;
-    LG_TRY (LAGraph_Malloc ((void **) &F, n, sizeof (GrB_Index), msg)) ;
-    LG_TRY (LAGraph_Malloc ((void **) &B, n, sizeof (GrB_Index), msg)) ;
-    LG_TRY (LAGraph_Malloc ((void **) &M, n, sizeof (GrB_Index), msg)) ;
-
-    for (GrB_Index i = 0; i < n; i++)
-        I[i] = V[i] = i;
-
-    // scc: the SCC identifier for each vertex
-    // scc[u] == n: not assigned yet
-    GRB_TRY (GrB_Vector_new (&scc, GrB_UINT64, n));
-    // vector of indices: ind[i] == i
-    GRB_TRY (GrB_Vector_new (&ind, GrB_UINT64, n));
-    GRB_TRY (GrB_Vector_build (ind, I, V, n, GrB_PLUS_UINT64));
-    // vector of infinite value: inf[i] == n
-    GRB_TRY (GrB_Vector_new (&inf, GrB_UINT64, n));
-    GRB_TRY (GrB_assign (inf, 0, 0, n, GrB_ALL, 0, 0));
-    // other vectors
-    GRB_TRY (GrB_Vector_new (&f, GrB_UINT64, n));
-    GRB_TRY (GrB_Vector_new (&b, GrB_UINT64, n));
-    GRB_TRY (GrB_Vector_new (&mask, GrB_UINT64, n));
-    GRB_TRY (GrB_IndexUnaryOp_new (&sel1, (void *) trim_one, GrB_BOOL, GrB_UINT64, GrB_UINT64));
-    GRB_TRY (GrB_IndexUnaryOp_new (&sel2, (void *) edge_removal, GrB_BOOL, GrB_UINT64, GrB_UINT64));
+    LG_ASSERT (is_csr, GrB_INVALID_VALUE) ;
 
     // remove trivial SCCs
     GRB_TRY (GrB_reduce (f, 0, GrB_PLUS_UINT64, GrB_PLUS_UINT64, FW, 0));
     GRB_TRY (GrB_reduce (b, 0, GrB_PLUS_UINT64, GrB_PLUS_UINT64, BW, 0));
-    GRB_TRY (GrB_eWiseMult (mask, 0, GxB_LAND_UINT64, GxB_LAND_UINT64, f, b, 0));
+    GRB_TRY (GrB_eWiseMult (mask, NULL, NULL, GrB_ONEB_BOOL, f, b, NULL));
     GRB_TRY (GrB_Vector_nvals (&nvals, mask));
 
     GRB_TRY (GrB_assign (scc, 0, 0, ind, GrB_ALL, 0, 0));
     GRB_TRY (GrB_assign (scc, mask, 0, n, GrB_ALL, 0, 0));
-    GRB_TRY (GrB_Vector_clear (mask));
 
     if (nvals < n)
     {
-        GRB_TRY (GrB_Vector_extractTuples (I, M, &n, scc));
-        GRB_TRY (GrB_select (FW, 0, 0, sel1, FW, 0, 0));
-        GRB_TRY (GrB_select (BW, 0, 0, sel1, BW, 0, 0));
+        // TODO this should be a single mxm with a diagonal mask matrix.
+        // No reason for context. 
+        GRB_TRY (GrB_Vector_extractTuples (NULL, contx.F, &n, scc));
+        GRB_TRY (GrB_Matrix_select_UDT (
+            FW, NULL, NULL, sel1, FW, &contx, NULL)) ;
+        GRB_TRY (GrB_Matrix_select_UDT (
+            BW, NULL, NULL, sel1, BW, &contx, NULL)) ;
     }
 
     GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
     while (nvals > 0)
     {
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISEQ_UINT64, scc, inf, 0));
+        GRB_TRY (GrB_Vector_apply_BinaryOp2nd_UINT64 (
+            mask, NULL, NULL, GrB_EQ_UINT64, scc, n, NULL));
         GRB_TRY (GrB_assign (f, 0, 0, ind, GrB_ALL, 0, 0));
         LG_TRY (propagate (f, mask, FW, BW, n, msg));
 
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISEQ_UINT64, f, ind, 0));
-        GRB_TRY (GrB_assign (b, 0, 0, inf, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, ind, 0));
+        GRB_TRY (GrB_Vector_assign_UINT64 (
+            b, NULL, NULL, n, GrB_ALL, 0, NULL)) ;
         GRB_TRY (GrB_assign (b, mask, 0, ind, GrB_ALL, 0, 0));
         LG_TRY (propagate (b, mask, BW, FW, n, msg));
 
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISEQ_UINT64, f, b, 0));
+        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, b, 0));
         GRB_TRY (GrB_assign (scc, mask, GrB_MIN_UINT64, f, GrB_ALL, 0, 0));
 
-        GRB_TRY (GrB_Vector_extractTuples (I, F, &n, f));
-        GRB_TRY (GrB_Vector_extractTuples (I, B, &n, b));
-        GRB_TRY (GrB_Vector_extractTuples (I, M, &n, mask));
+        GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.F, &n, f));
+        GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.B, &n, b));
+        GRB_TRY (GrB_Vector_extractTuples_BOOL (NULL, contx.M, &n, mask));
 
-        GRB_TRY (GrB_select (FW, 0, 0, sel2, FW, 0, 0));
-        GRB_TRY (GrB_select (BW, 0, 0, sel2, BW, 0, 0));
+        GRB_TRY (GrB_Matrix_select_UDT (
+            FW, NULL, NULL, sel2, FW, &contx, NULL)) ;
+        GRB_TRY (GrB_Matrix_select_UDT (
+            BW, NULL, NULL, sel2, BW, &contx, NULL)) ;
 
         GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
     }
-    GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISEQ_UINT64, scc, inf, 0));
+    GRB_TRY (GrB_Vector_apply_BinaryOp2nd_UINT64 (
+            mask, NULL, NULL, GrB_EQ_UINT64, scc, n, NULL));
     GRB_TRY (GrB_assign (scc, mask, 0, ind, GrB_ALL, 0, 0));
-
-    GRB_TRY (GrB_eWiseMult (mask, 0, 0, GxB_ISEQ_UINT64, scc, ind, 0));
-    GRB_TRY (GrB_reduce (&nvals, 0, GrB_PLUS_MONOID_UINT64, mask, 0));
 
     *result = scc;
     scc = NULL;

--- a/experimental/algorithm/LAGraph_scc.c
+++ b/experimental/algorithm/LAGraph_scc.c
@@ -106,22 +106,62 @@ void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContex
 #undef  LG_FREE_ALL
 #define LG_FREE_ALL    \
     GrB_free (&s) ;    \
-    GrB_free (&t) ;
+    GrB_free (&t) ;    \
+    GrB_free (&con_s)
 
+#if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
 static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
-        GrB_Matrix A, GrB_Matrix AT, GrB_Index n, char *msg)
+        const GrB_Matrix A, const GrB_Matrix AT, GrB_Index n, char *msg)
 {
     GrB_Info info;
     // semirings
-
     GrB_Vector s = NULL, t = NULL;
+    GxB_Container con_s = NULL;
+    GRB_TRY (GxB_Container_new (&con_s));
+    GRB_TRY (GxB_unload_Vector_into_Container(label, con_s, NULL));
+    con_s->format = GxB_BITMAP;
+    GRB_TRY (GrB_free(&con_s->b)) ;
+    con_s->b = mask;
+    mask = NULL;
+    GRB_TRY (GrB_Vector_new (&t, GrB_UINT64, n));
+    GRB_TRY (GrB_assign (t, 0, 0, con_s->x, GrB_ALL, 0, 0));
+    GRB_TRY (GrB_wait(A, GrB_MATERIALIZE));
+
+    bool active;
+    while (true)
+    {
+        GRB_TRY (GxB_load_Vector_from_Container(label, con_s, NULL)) ;
+        GRB_TRY (GrB_vxm (t, 0, GrB_MIN_UINT64,
+                                 GrB_MIN_FIRST_SEMIRING_UINT64, s, A, 0));
+        GRB_TRY (GxB_unload_Vector_into_Container(label, con_s, NULL));
+        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_NE_UINT64, t, con_s->x, 0));
+        GRB_TRY (GrB_assign (con_s->x, NULL, NULL, t, GrB_ALL, n, NULL));
+        GRB_TRY (GrB_reduce (&active, 0, GrB_LOR_MONOID_BOOL, co, 0));
+        if (!active) break;
+        GRB_TRY (GrB_Vector_clear(s));
+        GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_wait(s, GrB_MATERIALIZE));
+    }
+
+    LG_FREE_ALL ;
+    return GrB_SUCCESS;
+}
+#else
+static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
+        const GrB_Matrix A, const GrB_Matrix AT, GrB_Index n, char *msg)
+{
+    GrB_Info info;
+    // semirings
+    GrB_Vector s = NULL, t = NULL;
+    GrB_Scalar con_s = NULL;
     GRB_TRY (GrB_Vector_new (&s, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&t, GrB_UINT64, n));
     GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
     // GxB_fprint(s, GxB_SHORT, stdout);
     GRB_TRY (GrB_assign (t, 0, 0, label, GrB_ALL, 0, 0));
+    GRB_TRY (GrB_wait(A, GrB_MATERIALIZE));
 
-    GrB_Index active;
+    bool active;
     while (true)
     {
         // GRB_TRY (GrB_mxv 
@@ -129,24 +169,25 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
         GRB_TRY (GrB_vxm (t, 0, GrB_MIN_UINT64,
                                  GrB_MIN_FIRST_SEMIRING_UINT64, s, A, 0));
         GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_NE_UINT64, t, label, 0));
-        GRB_TRY (GrB_assign (label, mask, 0, t, GrB_ALL, 0, 0));
-        GRB_TRY (GrB_reduce (&active, 0, GrB_PLUS_MONOID_UINT64, mask, 0));
-        if (active == 0) break;
-        GRB_TRY (GrB_Vector_clear (s));
+        GRB_TRY (GrB_assign (label, NULL, NULL, t, GrB_ALL, n, NULL));
+        GRB_TRY (GrB_reduce (&active, 0, GrB_LOR_MONOID_BOOL, mask, 0));
+        if (!active) break;
+        GRB_TRY (GrB_Vector_clear(s));
         GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_wait(s, GrB_MATERIALIZE));
     }
 
     LG_FREE_ALL ;
     return GrB_SUCCESS;
 }
-
+#endif
 //****************************************************************************
 
 #undef  LG_FREE_ALL
 #define LG_FREE_ALL                         \
-    LAGraph_Free ((void **) &contx.F, msg);       \
-    LAGraph_Free ((void **) &contx.B, msg);       \
-    LAGraph_Free ((void **) &contx.M, msg);       \
+    LAGraph_Free ((void **) &contx.F, msg); \
+    LAGraph_Free ((void **) &contx.B, msg); \
+    LAGraph_Free ((void **) &contx.M, msg); \
     GrB_free (&ind);                        \
     GrB_free (&inf);                        \
     GrB_free (&f);                          \
@@ -196,14 +237,11 @@ int LAGraph_scc
     GRB_TRY (GrB_Matrix_ncols (&ncols, A));
     LG_ASSERT(n == ncols, GrB_DIMENSION_MISMATCH);
     
-
+    #if !LG_SUITESPARSE_GRAPHBLAS_V10
     LG_TRY (LAGraph_Malloc ((void **) &contx.F, n, sizeof (uint64_t), msg)) ;
     LG_TRY (LAGraph_Malloc ((void **) &contx.B, n, sizeof (uint64_t), msg)) ;
     LG_TRY (LAGraph_Malloc ((void **) &contx.M, n, sizeof (bool), msg)) ;
-    // LG_TRY (LAGraph_Malloc (&contx.data, 3 * n, sizeof (uint64_t), msg)) ;
-    // contx.F = (uint64_t *) contx.data;
-    // contx.B = (contx.F) + n;
-    // contx.M = (contx.F) + 2 * n;
+    #endif
     // scc: the SCC identifier for each vertex
     // scc[u] == n: not assigned yet
     GRB_TRY (GrB_Vector_new (&scc, GrB_UINT64, n));
@@ -265,12 +303,20 @@ int LAGraph_scc
         // GRB_TRY (GrB_Matrix_diag(&D, mask, 0)) ;
         // TODO this should be a single mxm with a diagonal mask matrix.
         // No reason for context. 
-        GRB_TRY (GrB_Vector_extractTuples (NULL, contx.F, &n, scc));
+        #if LG_SUITESPARSE_GRAPHBLAS_V10
+        GRB_TRY(GxB_Vector_unload(
+            scc, (void **) &contx.F, &type_F, &n_F, &size_F, &hand_F, NULL)) ;
+        #else
+        GRB_TRY (GrB_Vector_extractTuples_UINT64 (NULL, contx.F, &n, scc));
+        #endif
         GRB_TRY (GrB_Matrix_select_UDT (
             FW, NULL, NULL, sel1, FW, &contx, NULL)) ;
         GRB_TRY (GrB_Matrix_select_UDT (
             BW, NULL, NULL, sel1, BW, &contx, NULL)) ;
-        // GRB_TRY (GrB_free(&D)) ;
+        #if LG_SUITESPARSE_GRAPHBLAS_V10
+        GRB_TRY(GxB_Vector_load(
+            scc, (void **) &contx.F, type_F, n_F, size_F, hand_F, NULL)) ;
+        #endif
     }
 
     GRB_TRY (GrB_Matrix_nvals (&nvals, FW));
@@ -289,7 +335,8 @@ int LAGraph_scc
 
         GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, b, 0));
         GRB_TRY (GrB_assign (scc, mask, GrB_MIN_UINT64, f, GrB_ALL, 0, 0));
-        #if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
+
+        #if LG_SUITESPARSE_GRAPHBLAS_V10
             GRB_TRY(GxB_Vector_unload(
                 f, (void **) &contx.F, &type_F, &n_F, &size_F, &hand_F, NULL)) ;
             GRB_TRY(GxB_Vector_unload(
@@ -307,7 +354,7 @@ int LAGraph_scc
             FW, NULL, NULL, sel2, FW, &contx, NULL)) ;
         GRB_TRY (GrB_Matrix_select_UDT (
             BW, NULL, NULL, sel2, BW, &contx, NULL)) ;
-        #if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
+        #if LG_SUITESPARSE_GRAPHBLAS_V10
             GRB_TRY(GxB_Vector_load(
                 f, (void **) &contx.F, type_F, n_F, size_F, hand_F, NULL)) ;
             GRB_TRY(GxB_Vector_load(

--- a/experimental/algorithm/LAGraph_scc.c
+++ b/experimental/algorithm/LAGraph_scc.c
@@ -105,55 +105,17 @@ void trim_one (bool *z, const void *x, GrB_Index i, GrB_Index j, const sccContex
 
 #undef  LG_FREE_ALL
 #define LG_FREE_ALL    \
+{                      \
     GrB_free (&s) ;    \
     GrB_free (&t) ;    \
-    GrB_free (&con_s)
-
-#if LG_SUITESPARSE_GRAPHBLAS_V10 && 0
-static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
-        const GrB_Matrix A, const GrB_Matrix AT, GrB_Index n, char *msg)
-{
-    GrB_Info info;
-    // semirings
-    GrB_Vector s = NULL, t = NULL;
-    GxB_Container con_s = NULL;
-    GRB_TRY (GxB_Container_new (&con_s));
-    GRB_TRY (GxB_unload_Vector_into_Container(label, con_s, NULL));
-    con_s->format = GxB_BITMAP;
-    GRB_TRY (GrB_free(&con_s->b)) ;
-    con_s->b = mask;
-    mask = NULL;
-    GRB_TRY (GrB_Vector_new (&t, GrB_UINT64, n));
-    GRB_TRY (GrB_assign (t, 0, 0, con_s->x, GrB_ALL, 0, 0));
-    GRB_TRY (GrB_wait(A, GrB_MATERIALIZE));
-
-    bool active;
-    while (true)
-    {
-        GRB_TRY (GxB_load_Vector_from_Container(label, con_s, NULL)) ;
-        GRB_TRY (GrB_vxm (t, 0, GrB_MIN_UINT64,
-                                 GrB_MIN_FIRST_SEMIRING_UINT64, s, A, 0));
-        GRB_TRY (GxB_unload_Vector_into_Container(label, con_s, NULL));
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_NE_UINT64, t, con_s->x, 0));
-        GRB_TRY (GrB_assign (con_s->x, NULL, NULL, t, GrB_ALL, n, NULL));
-        GRB_TRY (GrB_reduce (&active, 0, GrB_LOR_MONOID_BOOL, co, 0));
-        if (!active) break;
-        GRB_TRY (GrB_Vector_clear(s));
-        GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
-        GRB_TRY (GrB_wait(s, GrB_MATERIALIZE));
-    }
-
-    LG_FREE_ALL ;
-    return GrB_SUCCESS;
 }
-#else
+
 static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
         const GrB_Matrix A, const GrB_Matrix AT, GrB_Index n, char *msg)
 {
     GrB_Info info;
     // semirings
     GrB_Vector s = NULL, t = NULL;
-    GrB_Scalar con_s = NULL;
     GRB_TRY (GrB_Vector_new (&s, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&t, GrB_UINT64, n));
     GRB_TRY (GrB_assign (s, mask, 0, label, GrB_ALL, 0, 0));
@@ -180,7 +142,6 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
     LG_FREE_ALL ;
     return GrB_SUCCESS;
 }
-#endif
 //****************************************************************************
 
 #undef  LG_FREE_ALL
@@ -193,6 +154,7 @@ static GrB_Info propagate (GrB_Vector label, GrB_Vector mask,
     GrB_free (&f);                          \
     GrB_free (&b);                          \
     GrB_free (&D);                          \
+    GrB_free (&x);                          \
     GrB_free (&mask);                       \
     GrB_free (&m2);                         \
     GrB_free (&FW);                         \
@@ -247,12 +209,13 @@ int LAGraph_scc
     GRB_TRY (GrB_Vector_new (&scc, GrB_UINT64, n));
     // vector of indices: ind[i] == i
     GRB_TRY (GrB_Vector_new (&ind, GrB_UINT64, n));
-    GRB_TRY (GrB_Vector_assign_UINT64 (ind, NULL, NULL, 0, GrB_ALL, n, NULL)) ;
+    GRB_TRY (GrB_Vector_assign_UINT64 (
+        ind, NULL, NULL, (uint64_t) 0, GrB_ALL, n, NULL)) ;
     GRB_TRY (GrB_Vector_apply_IndexOp_UINT64 (
         ind, NULL, NULL, GrB_ROWINDEX_INT64, ind, 0, NULL)) ;
     // vector of infinite value: inf[i] == n
     GRB_TRY (GrB_Vector_new (&inf, GrB_UINT64, n));
-    GRB_TRY (GrB_assign (inf, 0, 0, n, GrB_ALL, 0, 0));
+    GRB_TRY (GrB_assign (inf, NULL, NULL, n, GrB_ALL, 0, NULL));
     // other vectors
     GRB_TRY (GrB_Vector_new (&f, GrB_UINT64, n));
     GRB_TRY (GrB_Vector_new (&b, GrB_UINT64, n));
@@ -261,6 +224,7 @@ int LAGraph_scc
     GRB_TRY (GrB_Vector_new (&x, GrB_BOOL, n));
     GRB_TRY (GxB_Type_new (
         &contx_type, sizeof(sccContext), "sccContext", SCCCONTEXT)) ;
+
     GRB_TRY (GxB_IndexUnaryOp_new (
         &sel1, (GxB_index_unary_function) trim_one, 
         GrB_BOOL, GrB_UINT64, contx_type, 
@@ -279,7 +243,7 @@ int LAGraph_scc
     GRB_TRY (GrB_Matrix_new (&BW, GrB_BOOL, n, n));
     GRB_TRY (GrB_Matrix_assign_BOOL(
         FW, A, NULL, true, GrB_ALL, n, GrB_ALL, n, GrB_DESC_S)) ;
-    GRB_TRY (GrB_transpose (BW, 0, 0, FW, 0));     // BW = FW'
+    GRB_TRY (GrB_transpose (BW, NULL, NULL, FW, NULL));     // BW = FW'
        
     // check format
     int32_t A_format, AT_format;
@@ -295,13 +259,11 @@ int LAGraph_scc
     GRB_TRY (GrB_mxv (mask, m2, NULL, GxB_ANY_PAIR_BOOL, BW, x, GrB_DESC_S)) ;
     GRB_TRY (GrB_Vector_nvals (&nvals, mask));
 
-    GRB_TRY (GrB_assign (scc, 0, 0, ind, GrB_ALL, 0, 0));
-    GRB_TRY (GrB_assign (scc, mask, 0, n, GrB_ALL, 0, 0));
+    GRB_TRY (GrB_assign (scc, NULL, NULL, ind, GrB_ALL, 0, NULL));
+    GRB_TRY (GrB_assign (scc, mask, NULL, n, GrB_ALL, 0, NULL));
 
     if (nvals < n)
     {
-        // GRB_TRY (GrB_Matrix_diag(&D, mask, 0)) ;
-        // TODO this should be a single mxm with a diagonal mask matrix.
         // No reason for context. 
         #if LG_SUITESPARSE_GRAPHBLAS_V10
         GRB_TRY(GxB_Vector_unload(
@@ -324,17 +286,17 @@ int LAGraph_scc
     {
         GRB_TRY (GrB_Vector_apply_BinaryOp2nd_UINT64 (
             mask, NULL, NULL, GrB_EQ_UINT64, scc, n, NULL));
-        GRB_TRY (GrB_assign (f, 0, 0, ind, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_assign (f, NULL, NULL, ind, GrB_ALL, 0, NULL));
         LG_TRY (propagate (f, mask, FW, BW, n, msg));
 
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, ind, 0));
+        GRB_TRY (GrB_eWiseMult (mask, NULL, NULL, GrB_EQ_UINT64, f, ind, NULL));
         GRB_TRY (GrB_Vector_assign_UINT64 (
             b, NULL, NULL, n, GrB_ALL, 0, NULL)) ;
-        GRB_TRY (GrB_assign (b, mask, 0, ind, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_assign (b, mask, NULL, ind, GrB_ALL, 0, NULL));
         LG_TRY (propagate (b, mask, BW, FW, n, msg));
 
-        GRB_TRY (GrB_eWiseMult (mask, 0, 0, GrB_EQ_UINT64, f, b, 0));
-        GRB_TRY (GrB_assign (scc, mask, GrB_MIN_UINT64, f, GrB_ALL, 0, 0));
+        GRB_TRY (GrB_eWiseMult (mask, NULL, NULL, GrB_EQ_UINT64, f, b, NULL));
+        GRB_TRY (GrB_assign (scc, mask, GrB_MIN_UINT64, f, GrB_ALL, 0, NULL));
 
         #if LG_SUITESPARSE_GRAPHBLAS_V10
             GRB_TRY(GxB_Vector_unload(
@@ -367,7 +329,7 @@ int LAGraph_scc
     }
     GRB_TRY (GrB_Vector_apply_BinaryOp2nd_UINT64 (
             mask, NULL, NULL, GrB_EQ_UINT64, scc, n, NULL));
-    GRB_TRY (GrB_assign (scc, mask, 0, ind, GrB_ALL, 0, 0));
+    GRB_TRY (GrB_assign (scc, mask, NULL, ind, GrB_ALL, 0, NULL));
 
     *result = scc;
     scc = NULL;

--- a/experimental/benchmark/scc_demo.c
+++ b/experimental/benchmark/scc_demo.c
@@ -1,0 +1,196 @@
+//------------------------------------------------------------------------------
+// LAGraph/src/benchmark/cc_demo.c: benchmark LAGr_ConnectedComponents
+//------------------------------------------------------------------------------
+
+// LAGraph, (c) 2019-2022 by The LAGraph Contributors, All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// For additional details (including references to third party source code and
+// other files) see the LICENSE file or contact permission@sei.cmu.edu. See
+// Contributors.txt for a full list of contributors. Created, in part, with
+// funding and support from the U.S. Government (see Acknowledgments.txt file).
+// DM22-0790
+
+// Contributed by Timothy A. Davis, Texas A&M University
+
+//------------------------------------------------------------------------------
+
+// Usage: test_cc can be used with both stdin or a file as its input,
+// in either grb or mtx format.
+
+//------------------------------------------------------------------------------
+
+#include "LAGraph_demo.h"
+#include "LAGraphX.h"
+#include "LG_alg_internal.h"
+
+#undef  LG_FREE_ALL
+#define LG_FREE_ALL                 \
+{                                   \
+    LAGraph_Delete (&G, NULL) ;     \
+    GrB_free (&components) ;        \
+    GrB_free (&components2) ;       \
+}
+
+// to run just once, with p = omp_get_max_threads() threads
+#define NTHREAD_LIST 1
+#define THREAD_LIST 0
+
+// to run with p and p/2 threads, if p = omp_get_max_threads()
+// #define NTHREAD_LIST 2
+// #define THREAD_LIST 0
+
+// #define NTHREAD_LIST 7
+// #define THREAD_LIST 32, 24, 16, 8, 4, 2, 1
+
+// #define NTHREAD_LIST 4
+// #define THREAD_LIST 32, 24, 16, 8
+
+// #define NTHREAD_LIST 6
+// #define THREAD_LIST 64, 32, 24, 12, 8, 4
+
+GrB_Index countCC (GrB_Vector f, GrB_Index n)
+{
+    GrB_Index nCC = 0;
+    GrB_Index *w_val = NULL ;
+    LAGraph_Malloc ((void **) &w_val, n, sizeof (GrB_Index), NULL) ;
+    if (w_val == NULL) { printf ("out of memory\n") ; abort ( ) ; }
+    GrB_Index *i_val = NULL ;
+    #if LAGRAPH_SUITESPARSE
+    // SuiteSparse:GraphBLAS allows NULL inputs to GrB_Vector_extractTuples
+    #else
+    LAGraph_Malloc ((void **) &i_val, n, sizeof (GrB_Index), NULL) ;
+    if (i_val == NULL) { printf ("out of memory\n") ; abort ( ) ; }
+    #endif
+    GrB_Vector_extractTuples (i_val, w_val, &n, f) ;
+    for (GrB_Index i = 0; i < n; i++)
+    {
+        if (w_val[i] == i)
+        {
+            nCC++ ;
+        }
+    }
+    LAGraph_Free ((void **) &i_val, NULL) ;
+    LAGraph_Free ((void **) &w_val, NULL) ;
+    return nCC;
+}
+
+int main (int argc, char **argv)
+{
+
+    char msg [LAGRAPH_MSG_LEN] ;
+
+    LAGraph_Graph G = NULL ;
+    GrB_Vector components = NULL, components2 = NULL ;
+
+    // start GraphBLAS and LAGraph
+    bool burble = false ;
+    demo_init (burble) ;
+
+    int nt = NTHREAD_LIST ;
+    int Nthreads [20] = { 0, THREAD_LIST } ;
+    int nthreads_max, nthreads_outer, nthreads_inner ;
+    LAGRAPH_TRY (LAGraph_GetNumThreads (&nthreads_outer, &nthreads_inner, msg)) ;
+    nthreads_max = nthreads_outer * nthreads_inner ;
+    if (Nthreads [1] == 0)
+    {
+        // create thread list automatically
+        Nthreads [1] = nthreads_max ;
+        for (int t = 2 ; t <= nt ; t++)
+        {
+            Nthreads [t] = Nthreads [t-1] / 2 ;
+            if (Nthreads [t] == 0) nt = t-1 ;
+        }
+    }
+    printf ("threads to test: ") ;
+    for (int t = 1 ; t <= nt ; t++)
+    {
+        int nthreads = Nthreads [t] ;
+        if (nthreads > nthreads_max) continue ;
+        printf (" %d", nthreads) ;
+    }
+    printf ("\n") ;
+
+    //--------------------------------------------------------------------------
+    // read in the graph
+    //--------------------------------------------------------------------------
+
+    char *matrix_name = (argc > 1) ? argv [1] : "stdin" ;
+    printf ("\n%s:\n", matrix_name) ;
+    LAGRAPH_TRY (readproblem (&G,
+        NULL,   // no source nodes
+        false,  // make the graph directed
+        false,  // do not remove self-edges
+        true,   // structural only, no values needed
+        NULL,   // no type preference
+        false,  // do not ensure all entries positive
+        argc, argv)) ;
+    GrB_Index n, nvals ;
+    GRB_TRY (GrB_Matrix_nrows (&n, G->A)) ;
+    GRB_TRY (GrB_Matrix_nvals (&nvals, G->A)) ;
+    fflush (stdout) ; fflush (stderr) ;
+
+    //--------------------------------------------------------------------------
+    // begin tests
+    //--------------------------------------------------------------------------
+
+    // warmup
+    LAGRAPH_TRY (LAGraph_scc (&components, G->A, msg)) ;
+    GrB_Index nCC = countCC (components, n) ;
+    printf ("nCC: %llu\n", (long long unsigned int) nCC) ;
+
+#if 0 & LG_CHECK_RESULT
+    double tcheck = LAGraph_WallClockTime ( ) ;
+    int result = LG_check_cc (components, G, msg) ;
+    if (result != 0)
+    {
+        printf ("test failure: (%d) %s\n", result, msg) ;
+    }
+    tcheck = LAGraph_WallClockTime ( ) - tcheck ;
+    LAGRAPH_TRY (result) ;
+    printf ("LG_check_cc passed, time: %g\n", tcheck) ;
+#endif
+
+    #define NTRIALS 16
+    // #define NTRIALS 1
+    printf ("# of trials: %d\n\n", NTRIALS) ;
+    fflush (stdout) ; fflush (stderr) ;
+
+    //--------------------------------------------------------------------------
+    // LAGr_ConnectedComponents
+    //--------------------------------------------------------------------------
+
+    for (int trial = 1 ; trial <= nt ; trial++)
+    {
+        int nthreads = Nthreads [trial] ;
+        if (nthreads > nthreads_max) continue ;
+        LAGRAPH_TRY (LAGraph_SetNumThreads (1, nthreads, NULL)) ;
+        double ttt = 0 ;
+        int ntrials = NTRIALS ;
+        for (int k = 0 ; k < ntrials ; k++)
+        {
+            GrB_free (&components2) ;
+            double ttrial = LAGraph_WallClockTime ( ) ;
+            LAGRAPH_TRY (LAGraph_scc (&components2, G->A, msg)) ;
+            ttrial = LAGraph_WallClockTime ( ) - ttrial ;
+            ttt += ttrial ;
+            printf ("SCC:      nthreads: %2d trial: %2d time: %10.4f sec\n",
+                nthreads, k, ttrial) ;
+            GrB_Index nCC2 = countCC (components2, n) ;
+            if (nCC != nCC2) printf ("failure! %g %g diff %g\n",
+                (double) nCC, (double) nCC2, (double) (nCC-nCC2)) ;
+            fflush (stdout) ; fflush (stderr) ;
+        }
+        ttt = ttt / ntrials ;
+
+        printf (         "Avg: CC threads %3d: %10.3f sec, graph: %s\n",
+                nthreads, ttt, matrix_name) ;
+        fprintf (stderr, "Avg: CC threads %3d: %10.3f sec, graph: %s\n",
+                nthreads, ttt, matrix_name) ;
+        fflush (stdout) ; fflush (stderr) ;
+
+    }
+    LG_FREE_ALL ;
+    LAGRAPH_TRY (LAGraph_Finalize (msg)) ;
+    return (GrB_SUCCESS) ;
+}

--- a/experimental/test/test_scc.c
+++ b/experimental/test/test_scc.c
@@ -33,6 +33,8 @@ char filename [LEN+1] ;
 typedef struct
 {
     const char *name ;
+    int cc_count;
+    uint64_t hash;
 }
 matrix_info ;
 
@@ -40,59 +42,84 @@ int scc_cover [7] = { 0, 0, 2, 0, 4, 2, 0 } ;
 
 const matrix_info files [ ] =
 {
-    { "A2.mtx" },
-    { "A.mtx" },
-    { "bcsstk13.mtx" },
-    { "cover.mtx" },
-    { "cover_structure.mtx" },
-    { "cryg2500.mtx" },
-    { "full.mtx" },
-    { "full_noheader.mtx" },
-    { "full_symmetric.mtx" },
-    { "jagmesh7.mtx" },
-    { "karate.mtx" },
-    { "ldbc-cdlp-directed-example.mtx" },
-    { "ldbc-cdlp-undirected-example.mtx" },
-    { "ldbc-directed-example-bool.mtx" },
-    { "ldbc-directed-example.mtx" },
-    { "ldbc-directed-example-unweighted.mtx" },
-    { "ldbc-undirected-example-bool.mtx" },
-    { "ldbc-undirected-example.mtx" },
-    { "ldbc-undirected-example-unweighted.mtx" },
-    { "ldbc-wcc-example.mtx" },
-    { "LFAT5.mtx" },
-    { "LFAT5_two.mtx" },
-    { "matrix_bool.mtx" },
-    { "matrix_fp32.mtx" },
-    { "matrix_fp32_structure.mtx" },
-    { "matrix_fp64.mtx" },
-    { "matrix_int16.mtx" },
-    { "matrix_int32.mtx" },
-    { "matrix_int64.mtx" },
-    { "matrix_int8.mtx" },
-    { "matrix_uint16.mtx" },
-    { "matrix_uint32.mtx" },
-    { "matrix_uint64.mtx" },
-    { "matrix_uint8.mtx" },
-    { "msf1.mtx" },
-    { "msf2.mtx" },
-    { "msf3.mtx" },
-    { "olm1000.mtx" },
-    { "pushpull.mtx" },
-    { "sample2.mtx" },
-    { "sample.mtx" },
-    { "structure.mtx" },
-    { "test_BF.mtx" },
-    { "test_FW_1000.mtx" },
-    { "test_FW_2003.mtx" },
-    { "test_FW_2500.mtx" },
-    { "tree-example.mtx" },
-    { "west0067_jumbled.mtx" },
-    { "west0067.mtx" },
-    { "west0067_noheader.mtx" },
-    { "zenios.mtx" },
-    { "" },
+    { "A2.mtx", 1, 6493938657738929428ull},
+    { "A.mtx", 1, 6493938657738929428ull},
+    { "bcsstk13.mtx", 1, 4873650117803742346ull},
+    { "cover.mtx", 3, 848279640410529436ull},
+    { "cover_structure.mtx", 3, 848279640410529436ull},
+    { "cryg2500.mtx", 1, 8070599988610413093ull},
+    { "full.mtx", 1, 15769435293242772098ull},
+    { "full_noheader.mtx", 1, 15769435293242772098ull},
+    { "full_symmetric.mtx", 1, 7920595475144714245ull},
+    { "jagmesh7.mtx", 1, 5114200449021899176ull},
+    { "karate.mtx", 1, 4176608668907330736ull},
+    { "ldbc-cdlp-directed-example.mtx", 2, 11183292771650049706ull},
+    { "ldbc-cdlp-undirected-example.mtx", 1, 4918287057298807835ull},
+    { "ldbc-directed-example-bool.mtx", 7, 11304580677056001228ull},
+    { "ldbc-directed-example.mtx", 7, 11304580677056001228ull},
+    { "ldbc-directed-example-unweighted.mtx", 7, 11304580677056001228ull},
+    { "ldbc-undirected-example-bool.mtx", 1, 9158223257798130275ull},
+    { "ldbc-undirected-example.mtx", 1, 9158223257798130275ull},
+    { "ldbc-undirected-example-unweighted.mtx", 1, 9158223257798130275ull},
+    { "ldbc-wcc-example.mtx", 1, 4317729120311459500ull},
+    { "LFAT5.mtx", 3, 17553140753101484131ull},
+    { "LFAT5_two.mtx", 6, 7979561620824911ull},
+    { "matrix_bool.mtx", 3, 848279640410529436ull},
+    { "matrix_fp32.mtx", 3, 848279640410529436ull},
+    { "matrix_fp32_structure.mtx", 3, 848279640410529436ull},
+    { "matrix_fp64.mtx", 3, 848279640410529436ull},
+    { "matrix_int16.mtx", 3, 848279640410529436ull},
+    { "matrix_int32.mtx", 3, 848279640410529436ull},
+    { "matrix_int64.mtx", 3, 848279640410529436ull},
+    { "matrix_int8.mtx", 3, 848279640410529436ull},
+    { "matrix_uint16.mtx", 3, 848279640410529436ull},
+    { "matrix_uint32.mtx", 3, 848279640410529436ull},
+    { "matrix_uint64.mtx", 3, 848279640410529436ull},
+    { "matrix_uint8.mtx", 3, 848279640410529436ull},
+    { "msf1.mtx", 4, 3301616701375337755ull},
+    { "msf2.mtx", 8, 11227097946539390519ull},
+    { "msf3.mtx", 5, 5965767602828141907ull},
+    { "olm1000.mtx", 1, 14473458856538426155ull},
+    { "pushpull.mtx", 1, 14764381483900318255ull},
+    { "sample2.mtx", 1, 4918287057298807835ull},
+    { "sample.mtx", 8, 11227097946539390519ull},
+    { "structure.mtx", 3, 848279640410529436ull},
+    { "test_BF.mtx", 3, 848279640410529436ull},
+    { "test_FW_1000.mtx", 1, 14473458856538426155ull},
+    { "test_FW_2003.mtx", 485, 13924889949050000093ull},
+    { "test_FW_2500.mtx", 646, 9579946550331191330ull},
+    { "tree-example.mtx", 1, 16959292359894689422ull},
+    { "west0067_jumbled.mtx", 1, 15563611237648677666ull},
+    { "west0067.mtx", 1, 15563611237648677666ull},
+    { "west0067_noheader.mtx", 1, 15563611237648677666ull},
+    { "zenios.mtx", 1391, 10773678236411609506ull},
+    { "", 0, 0},
 } ;
+//------------------------------------------------------------------------------
+// count_connected_components: count the # of components in a component vector
+//------------------------------------------------------------------------------
+
+int count_connected_components (GrB_Vector C, uint64_t *vector_hash) ;
+
+int count_connected_components (GrB_Vector C, uint64_t *vector_hash)
+{
+    GrB_Index n = 0 ;
+    OK (GrB_Vector_size (&n, C)) ;
+    int ncomponents = 0 ;
+    for (int i = 0 ; i < n ; i++)
+    {
+        int64_t comp = -1 ;
+        int result = GrB_Vector_extractElement (&comp, C, i) ;
+        if (result == GrB_SUCCESS && comp == i) ncomponents++ ;
+        //hash all of the values into one number
+        if (result == GrB_SUCCESS && vector_hash) 
+        {
+            (*vector_hash) *= 89734512321ull;
+            (*vector_hash) += comp + i;
+        }
+    }
+    return (ncomponents) ;
+}
 
 //****************************************************************************
 void test_scc (void)
@@ -114,14 +141,12 @@ void test_scc (void)
         OK (LAGraph_MMRead (&A, f, msg)) ;
         fclose (f) ;
 
-        // construct a directed graph G with adjacency matrix A
-        OK (LAGraph_New (&G, &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
-        TEST_CHECK (A == NULL) ;
-
         GrB_Vector c = NULL ;
 
         // find the strongly connected components with LAGraph_scc
-        OK (LAGraph_scc (&c, G->A, msg)) ;
+        // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
+        OK (LAGraph_scc (&c, A, msg)) ;
+        // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
 
         GrB_Index n ;
         OK (GrB_Vector_size (&n, c)) ;
@@ -144,11 +169,13 @@ void test_scc (void)
             TEST_CHECK (ok) ;
             OK (GrB_free (&cgood)) ;
         }
-
-        printf ("\nscc:\n") ;
+        uint64_t hash = 9238018047ull;
+        int result_cc_count = count_connected_components(c, &hash);
+        TEST_CHECK(result_cc_count == files[k].cc_count);
+        TEST_CHECK(hash == files[k].hash);
         OK (LAGraph_Vector_Print (c, pr, stdout, msg)) ;
         OK (GrB_free (&c)) ;
-        OK (LAGraph_Delete (&G, msg)) ;
+        OK (GrB_free (&A)) ;
     }
 
     LAGraph_Finalize (msg) ;

--- a/experimental/test/test_scc.c
+++ b/experimental/test/test_scc.c
@@ -42,66 +42,65 @@ int scc_cover [7] = { 0, 0, 2, 0, 4, 2, 0 } ;
 
 const matrix_info files [ ] =
 {
-    { "A2.mtx", 1, 6493938657738929428ull},
-    { "A.mtx", 1, 6493938657738929428ull},
-    { "bcsstk13.mtx", 1, 4873650117803742346ull},
-    { "cover.mtx", 3, 848279640410529436ull},
-    { "cover_structure.mtx", 3, 848279640410529436ull},
-    { "cryg2500.mtx", 1, 8070599988610413093ull},
-    { "full.mtx", 1, 15769435293242772098ull},
-    { "full_noheader.mtx", 1, 15769435293242772098ull},
-    { "full_symmetric.mtx", 1, 7920595475144714245ull},
-    { "jagmesh7.mtx", 1, 5114200449021899176ull},
-    { "karate.mtx", 1, 4176608668907330736ull},
-    { "ldbc-cdlp-directed-example.mtx", 2, 11183292771650049706ull},
-    { "ldbc-cdlp-undirected-example.mtx", 1, 4918287057298807835ull},
-    { "ldbc-directed-example-bool.mtx", 7, 11304580677056001228ull},
-    { "ldbc-directed-example.mtx", 7, 11304580677056001228ull},
-    { "ldbc-directed-example-unweighted.mtx", 7, 11304580677056001228ull},
-    { "ldbc-undirected-example-bool.mtx", 1, 9158223257798130275ull},
-    { "ldbc-undirected-example.mtx", 1, 9158223257798130275ull},
-    { "ldbc-undirected-example-unweighted.mtx", 1, 9158223257798130275ull},
-    { "ldbc-wcc-example.mtx", 1, 4317729120311459500ull},
-    { "LFAT5.mtx", 3, 17553140753101484131ull},
-    { "LFAT5_two.mtx", 6, 7979561620824911ull},
-    { "matrix_bool.mtx", 3, 848279640410529436ull},
-    { "matrix_fp32.mtx", 3, 848279640410529436ull},
-    { "matrix_fp32_structure.mtx", 3, 848279640410529436ull},
-    { "matrix_fp64.mtx", 3, 848279640410529436ull},
-    { "matrix_int16.mtx", 3, 848279640410529436ull},
-    { "matrix_int32.mtx", 3, 848279640410529436ull},
-    { "matrix_int64.mtx", 3, 848279640410529436ull},
-    { "matrix_int8.mtx", 3, 848279640410529436ull},
-    { "matrix_uint16.mtx", 3, 848279640410529436ull},
-    { "matrix_uint32.mtx", 3, 848279640410529436ull},
-    { "matrix_uint64.mtx", 3, 848279640410529436ull},
-    { "matrix_uint8.mtx", 3, 848279640410529436ull},
-    { "msf1.mtx", 4, 3301616701375337755ull},
-    { "msf2.mtx", 8, 11227097946539390519ull},
-    { "msf3.mtx", 5, 5965767602828141907ull},
-    { "olm1000.mtx", 1, 14473458856538426155ull},
-    { "pushpull.mtx", 1, 14764381483900318255ull},
-    { "sample2.mtx", 1, 4918287057298807835ull},
-    { "sample.mtx", 8, 11227097946539390519ull},
-    { "structure.mtx", 3, 848279640410529436ull},
-    { "test_BF.mtx", 3, 848279640410529436ull},
-    { "test_FW_1000.mtx", 1, 14473458856538426155ull},
-    { "test_FW_2003.mtx", 485, 13924889949050000093ull},
-    { "test_FW_2500.mtx", 646, 9579946550331191330ull},
-    { "tree-example.mtx", 1, 16959292359894689422ull},
-    { "west0067_jumbled.mtx", 1, 15563611237648677666ull},
-    { "west0067.mtx", 1, 15563611237648677666ull},
-    { "west0067_noheader.mtx", 1, 15563611237648677666ull},
-    { "zenios.mtx", 1391, 10773678236411609506ull},
+    { "A2.mtx", 1, 0x2de8d717be626313},
+    { "A.mtx", 1, 0x2de8d717be626313},
+    { "bcsstk13.mtx", 1, 0x41d903f08b46b543},
+    { "cover.mtx", 3, 0x30ae8cb78a807691},
+    { "cover_structure.mtx", 3, 0x30ae8cb78a807691},
+    { "cryg2500.mtx", 1, 0xd1cb8e3cc6be967},
+    { "full.mtx", 1, 0x99971e4f016b4644},
+    { "full_noheader.mtx", 1, 0x99971e4f016b4644},
+    { "full_symmetric.mtx", 1, 0x278859fec1de1f7f},
+    { "jagmesh7.mtx", 1, 0x66b315eea17941c8},
+    { "karate.mtx", 1, 0x8bad7c50644c4aa9},
+    { "ldbc-cdlp-directed-example.mtx", 2, 0x3a61ac294b7bb114},
+    { "ldbc-cdlp-undirected-example.mtx", 1, 0x4072e255fd8e310a},
+    { "ldbc-directed-example-bool.mtx", 7, 0xc66f5ecf1b7f6876},
+    { "ldbc-directed-example.mtx", 7, 0xc66f5ecf1b7f6876},
+    { "ldbc-directed-example-unweighted.mtx", 7, 0xc66f5ecf1b7f6876},
+    { "ldbc-undirected-example-bool.mtx", 1, 0xf53db7dbbeff3283},
+    { "ldbc-undirected-example.mtx", 1, 0xf53db7dbbeff3283},
+    { "ldbc-undirected-example-unweighted.mtx", 1, 0xf53db7dbbeff3283},
+    { "ldbc-wcc-example.mtx", 1, 0x36a78022528a2101},
+    { "LFAT5.mtx", 3, 0x79d4d8de0a22a863},
+    { "LFAT5_two.mtx", 6, 0xac369d0362d73d6},
+    { "matrix_bool.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_fp32.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_fp32_structure.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_fp64.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_int16.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_int32.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_int64.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_int8.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_uint16.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_uint32.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_uint64.mtx", 3, 0x30ae8cb78a807691},
+    { "matrix_uint8.mtx", 3, 0x30ae8cb78a807691},
+    { "msf1.mtx", 4, 0x6445d984131a9555},
+    { "msf2.mtx", 8, 0x72d532720c54b673},
+    { "msf3.mtx", 5, 0xf57eb057beb5a5c7},
+    { "olm1000.mtx", 1, 0x15cf9ea2db88ab18},
+    { "pushpull.mtx", 1, 0x1816384cd04f7e01},
+    { "sample2.mtx", 1, 0x4072e255fd8e310a},
+    { "sample.mtx", 8, 0x72d532720c54b673},
+    { "structure.mtx", 3, 0x30ae8cb78a807691},
+    { "test_BF.mtx", 3, 0x30ae8cb78a807691},
+    { "test_FW_1000.mtx", 1, 0x15cf9ea2db88ab18},
+    { "test_FW_2003.mtx", 485, 0xf79ad45d3a704eec},
+    { "test_FW_2500.mtx", 646, 0x4fa83d60352e7e19},
+    { "tree-example.mtx", 1, 0x8857b82baeba129},
+    { "west0067_jumbled.mtx", 1, 0xa861dc7526128ac7},
+    { "west0067.mtx", 1, 0xa861dc7526128ac7},
+    { "west0067_noheader.mtx", 1, 0xa861dc7526128ac7},
+    { "zenios.mtx", 1391, 0x15b2b99a80c3480e},
     { "", 0, 0},
 } ;
+
 //------------------------------------------------------------------------------
 // count_connected_components: count the # of components in a component vector
 //------------------------------------------------------------------------------
 
-int count_connected_components (GrB_Vector C, uint64_t *vector_hash) ;
-
-int count_connected_components (GrB_Vector C, uint64_t *vector_hash)
+int count_connected_components (GrB_Vector C)
 {
     GrB_Index n = 0 ;
     OK (GrB_Vector_size (&n, C)) ;
@@ -111,12 +110,6 @@ int count_connected_components (GrB_Vector C, uint64_t *vector_hash)
         int64_t comp = -1 ;
         int result = GrB_Vector_extractElement (&comp, C, i) ;
         if (result == GrB_SUCCESS && comp == i) ncomponents++ ;
-        //hash all of the values into one number
-        if (result == GrB_SUCCESS && vector_hash) 
-        {
-            (*vector_hash) *= 89734512321ull;
-            (*vector_hash) += comp + i;
-        }
     }
     return (ncomponents) ;
 }
@@ -173,15 +166,13 @@ void test_scc (void)
                 TEST_CHECK (ok) ;
                 OK (GrB_free (&cgood)) ;
             }
-            uint64_t hash = 9238018047ull;
-            int result_cc_count = count_connected_components(c, &hash);
+            int result_cc_count = count_connected_components(c);
             TEST_CHECK(result_cc_count == files[k].cc_count);
-            TEST_CHECK(hash == files[k].hash);
             OK (LAGraph_Vector_Print (c, pr, stdout, msg)) ;
-            uint64_t hash2;
-            int hash_info = LAGraph_Hash_Vector(&hash2, c, msg); 
+            uint64_t hash = 0;
+            int hash_info = LAGraph_Hash_Vector(&hash, c, msg); 
             OK (hash_info);
-            printf("%lx\n", hash2);
+            TEST_CHECK(hash == files[k].hash);
             OK (GrB_free (&c)) ;
         }
         OK (GrB_free (&A)) ;

--- a/experimental/test/test_scc.c
+++ b/experimental/test/test_scc.c
@@ -143,38 +143,43 @@ void test_scc (void)
 
         GrB_Vector c = NULL ;
 
-        // find the strongly connected components with LAGraph_scc
-        // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
-        OK (LAGraph_scc (&c, A, msg)) ;
-        // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
-
-        GrB_Index n ;
-        OK (GrB_Vector_size (&n, c)) ;
-        LAGraph_PrintLevel pr = (n <= 100) ? LAGraph_COMPLETE : LAGraph_SHORT ;
-
-        // check result c for cover
-        if (strcmp (aname, "cover.mtx") == 0)
+        for (int jit = 0 ; jit <= 1 ; jit++)
         {
-            GrB_Vector cgood = NULL ;
-            OK (GrB_Vector_new (&cgood, GrB_UINT64, n)) ;
-            for (int k = 0 ; k < n ; k++)
+            OK (GxB_Global_Option_set (GxB_JIT_C_CONTROL,
+                jit ? GxB_JIT_ON : GxB_JIT_OFF)) ;
+            // find the strongly connected components with LAGraph_scc
+            // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
+            OK (LAGraph_scc (&c, A, msg)) ;
+            // GrB_set (GrB_GLOBAL, (int32_t) (true), GxB_BURBLE) ;
+
+            GrB_Index n ;
+            OK (GrB_Vector_size (&n, c)) ;
+            LAGraph_PrintLevel pr = (n <= 100) ? LAGraph_COMPLETE : LAGraph_SHORT ;
+
+            // check result c for cover
+            if (strcmp (aname, "cover.mtx") == 0)
             {
-                OK (GrB_Vector_setElement (cgood, scc_cover [k], k)) ;
+                GrB_Vector cgood = NULL ;
+                OK (GrB_Vector_new (&cgood, GrB_UINT64, n)) ;
+                for (int k = 0 ; k < n ; k++)
+                {
+                    OK (GrB_Vector_setElement (cgood, scc_cover [k], k)) ;
+                }
+                OK (GrB_wait (cgood, GrB_MATERIALIZE)) ;
+                printf ("\nscc (known result):\n") ;
+                OK (LAGraph_Vector_Print (cgood, pr, stdout, msg)) ;
+                bool ok = false ;
+                OK (LAGraph_Vector_IsEqual (&ok, c, cgood, msg)) ;
+                TEST_CHECK (ok) ;
+                OK (GrB_free (&cgood)) ;
             }
-            OK (GrB_wait (cgood, GrB_MATERIALIZE)) ;
-            printf ("\nscc (known result):\n") ;
-            OK (LAGraph_Vector_Print (cgood, pr, stdout, msg)) ;
-            bool ok = false ;
-            OK (LAGraph_Vector_IsEqual (&ok, c, cgood, msg)) ;
-            TEST_CHECK (ok) ;
-            OK (GrB_free (&cgood)) ;
+            uint64_t hash = 9238018047ull;
+            int result_cc_count = count_connected_components(c, &hash);
+            TEST_CHECK(result_cc_count == files[k].cc_count);
+            TEST_CHECK(hash == files[k].hash);
+            OK (LAGraph_Vector_Print (c, pr, stdout, msg)) ;
+            OK (GrB_free (&c)) ;
         }
-        uint64_t hash = 9238018047ull;
-        int result_cc_count = count_connected_components(c, &hash);
-        TEST_CHECK(result_cc_count == files[k].cc_count);
-        TEST_CHECK(hash == files[k].hash);
-        OK (LAGraph_Vector_Print (c, pr, stdout, msg)) ;
-        OK (GrB_free (&c)) ;
         OK (GrB_free (&A)) ;
     }
 

--- a/experimental/test/test_scc.c
+++ b/experimental/test/test_scc.c
@@ -178,6 +178,10 @@ void test_scc (void)
             TEST_CHECK(result_cc_count == files[k].cc_count);
             TEST_CHECK(hash == files[k].hash);
             OK (LAGraph_Vector_Print (c, pr, stdout, msg)) ;
+            uint64_t hash2;
+            int hash_info = LAGraph_Hash_Vector(&hash2, c, msg); 
+            OK (hash_info);
+            printf("%lx\n", hash2);
             OK (GrB_free (&c)) ;
         }
         OK (GrB_free (&A)) ;

--- a/experimental/utility/LAGraph_Matrix_Hash.c
+++ b/experimental/utility/LAGraph_Matrix_Hash.c
@@ -22,49 +22,65 @@
 #undef LG_FREE_ALL
 #define LG_FREE_ALL               \
 {                                 \
-    GrB_free(&x);                 \
-    GrB_free(&s);                 \
+    GrB_free(&C);                 \
     GrB_free(&lg_hash_edge);      \
-    GrB_free(&lg_hash_edge_biop); \
-    GrB_free(&lg_xor_hash);       \
 }
 
-static void hash_edge(
-    uint64_t *z, 
-    uint64_t *x,
-    GrB_Index ix, 
-    GrB_Index jx, 
-    uint64_t *y,
-    GrB_Index iy, 
-    GrB_Index jy, 
-    uint64_t thunk
+#define GOLDEN_GAMMA 0x9E3779B97F4A7C15LL
+
+// The init function computes a cheesy hash based on splitmix64t
+void hash_edge (uint64_t *z, const uint64_t *x,
+    GrB_Index i, GrB_Index j, const uint64_t *seed)
+{
+    uint64_t result = (i + j * i  + GOLDEN_GAMMA) ;
+    result = (result ^ (*x)) * 0xBF58476D1CE4E5B9LL ;
+    result = (result ^ (result >> 30)) * 0xBF58476D1CE4E5B9LL ;
+    result = (result ^ (result >> 27)) * 0x94D049BB133111EBLL ;
+    result = (result ^ (result >> 31)) ;
+    (*z) = result ;
+}
+
+#define HASH_EDGE_DEF \
+"void hash_edge (uint64_t *z, const uint64_t *x,\n"                            \
+"    GrB_Index i, GrB_Index j, const uint64_t *seed)\n"                        \
+"{\n"                                                                          \
+"    uint64_t result = (i + j * i  + 0x9E3779B97F4A7C15LL) ;\n"                \
+"    result = (result ^ (*x)) * 0xBF58476D1CE4E5B9LL ;\n"                      \
+"    result = (result ^ (result >> 30)) * 0xBF58476D1CE4E5B9LL ;\n"            \
+"    result = (result ^ (result >> 27)) * 0x94D049BB133111EBLL ;\n"            \
+"    result = (result ^ (result >> 31)) ;\n"                                   \
+"    (*z) = result ;\n"                                                        \
+"}\n"
+
+GrB_Info LAGraph_Hash_Matrix(
+    uint64_t *hash,      // [output] hash
+    const GrB_Matrix A,  // matrix to hash
+    char *msg
 ) {
-    uint64_t a = *x;
-    a ^= ix + 0x9e3779b97f4a7c15ULL;
-    a = (a << 13) | (a >> (64 - 13));
-    a ^= jx + 0x9e3779b97f4a7c15ULL;
-    a = (a << 17) | (a >> (64 - 17));
-    *z = a;
-}
-
-GrB_Info LAGraph_Hash_Vector(uint64_t *hash, GrB_Vector v, char *msg){
-    GrB_Vector x = NULL;
-    GrB_Scalar s = NULL;
-    GxB_IndexBinaryOp lg_hash_edge = NULL;
-    GrB_BinaryOp lg_hash_edge_biop = NULL;
-    GrB_Semiring lg_xor_hash = NULL;
-    GrB_Index nrows;
-    GRB_TRY (GrB_Vector_size(&nrows, v)) ;
-    GRB_TRY (GrB_Scalar_new(&s, GrB_UINT64)) ;
-    GRB_TRY (GrB_Scalar_setElement_UINT64(s, 0)) ;
-    GRB_TRY (GrB_Vector_new(&x, GrB_UINT64, nrows)) ;
-    GRB_TRY (GrB_Vector_assign_UINT64(x, NULL, NULL, (uint64_t) 0, GrB_ALL, 0, NULL)) ;
-    GRB_TRY (GxB_IndexBinaryOp_new(&lg_hash_edge, (GxB_index_binary_function) hash_edge,
-        GrB_UINT64, GrB_UINT64, GrB_UINT64, GrB_UINT64, NULL, NULL)) ;
-    GRB_TRY (GxB_BinaryOp_new_IndexOp(&lg_hash_edge_biop, lg_hash_edge, s)) ;
-    GRB_TRY (GrB_Semiring_new (&lg_xor_hash, GxB_BXOR_UINT64_MONOID, lg_hash_edge_biop)) ;
-    GRB_TRY (GrB_mxv((GrB_Vector) s, NULL, NULL, lg_xor_hash, (GrB_Matrix) v, x, GrB_DESC_T0)) ;
-    GRB_TRY (GrB_Scalar_extractElement_UINT64(hash, s)) ;
+    GrB_Matrix C = NULL;
+    GrB_IndexUnaryOp lg_hash_edge = NULL;
+    GrB_Index nrows, ncols;
+    GRB_TRY (GrB_Matrix_nrows(&nrows, A)) ;
+    GRB_TRY (GrB_Matrix_ncols(&ncols, A)) ;
+    GRB_TRY (GrB_Matrix_new(&C, GrB_UINT64, nrows, ncols)) ;
+    GRB_TRY (GxB_IndexUnaryOp_new(
+        &lg_hash_edge, (GxB_index_unary_function) hash_edge,
+        GrB_UINT64, GrB_UINT64, GrB_UINT64, "hash_edge", HASH_EDGE_DEF)) ;
+    
+    // TODO: C takes extra memory which is not nessesary for this computation.
+    // Compute without extra memory if possible.
+    GRB_TRY (GrB_Matrix_apply_IndexOp_UINT64(
+        C, NULL, NULL, lg_hash_edge, A, (uint64_t) 0, NULL));
+    GRB_TRY (GrB_Matrix_reduce_UINT64(
+        hash, GrB_BXOR_UINT64, GxB_BXOR_UINT64_MONOID, C, NULL)) ;
     LG_FREE_ALL;
     return GrB_SUCCESS;
+}
+
+GrB_Info LAGraph_Hash_Vector(
+    uint64_t *hash,       // [output] hash
+    const GrB_Vector v,   // Vector to hash
+    char *msg
+) {
+    return LAGraph_Hash_Matrix(hash, (GrB_Matrix) v, NULL);
 }

--- a/experimental/utility/LAGraph_Matrix_Hash.c
+++ b/experimental/utility/LAGraph_Matrix_Hash.c
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// LAGraph_Random_Matrix: generate a random matrix
+//------------------------------------------------------------------------------
+
+// LAGraph, (c) 2019-2022 by The LAGraph Contributors, All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// For additional details (including references to third party source code and
+// other files) see the LICENSE file or contact permission@sei.cmu.edu. See
+// Contributors.txt for a full list of contributors. Created, in part, with
+// funding and support from the U.S. Government (see Acknowledgments.txt file).
+// DM22-0790
+
+// Contributed by Timothy A. Davis, Texas A&M University
+
+//------------------------------------------------------------------------------
+
+#include "LG_internal.h"
+#include <LAGraph.h>
+#include <LAGraphX.h>
+
+#undef LG_FREE_ALL
+#define LG_FREE_ALL               \
+{                                 \
+    GrB_free(&x);                 \
+    GrB_free(&s);                 \
+    GrB_free(&lg_hash_edge);      \
+    GrB_free(&lg_hash_edge_biop); \
+    GrB_free(&lg_xor_hash);       \
+}
+
+static void hash_edge(
+    uint64_t *z, 
+    uint64_t *x,
+    GrB_Index ix, 
+    GrB_Index jx, 
+    uint64_t *y,
+    GrB_Index iy, 
+    GrB_Index jy, 
+    uint64_t thunk
+) {
+    uint64_t a = *x;
+    a ^= ix + 0x9e3779b97f4a7c15ULL;
+    a = (a << 13) | (a >> (64 - 13));
+    a ^= jx + 0x9e3779b97f4a7c15ULL;
+    a = (a << 17) | (a >> (64 - 17));
+    *z = a;
+}
+
+GrB_Info LAGraph_Hash_Vector(uint64_t *hash, GrB_Vector v, char *msg){
+    GrB_Vector x = NULL;
+    GrB_Scalar s = NULL;
+    GxB_IndexBinaryOp lg_hash_edge = NULL;
+    GrB_BinaryOp lg_hash_edge_biop = NULL;
+    GrB_Semiring lg_xor_hash = NULL;
+    GrB_Index nrows;
+    GRB_TRY (GrB_Vector_size(&nrows, v)) ;
+    GRB_TRY (GrB_Scalar_new(&s, GrB_UINT64)) ;
+    GRB_TRY (GrB_Scalar_setElement_UINT64(s, 0)) ;
+    GRB_TRY (GrB_Vector_new(&x, GrB_UINT64, nrows)) ;
+    GRB_TRY (GrB_Vector_assign_UINT64(x, NULL, NULL, (uint64_t) 0, GrB_ALL, 0, NULL)) ;
+    GRB_TRY (GxB_IndexBinaryOp_new(&lg_hash_edge, (GxB_index_binary_function) hash_edge,
+        GrB_UINT64, GrB_UINT64, GrB_UINT64, GrB_UINT64, NULL, NULL)) ;
+    GRB_TRY (GxB_BinaryOp_new_IndexOp(&lg_hash_edge_biop, lg_hash_edge, s)) ;
+    GRB_TRY (GrB_Semiring_new (&lg_xor_hash, GxB_BXOR_UINT64_MONOID, lg_hash_edge_biop)) ;
+    GRB_TRY (GrB_mxv((GrB_Vector) s, NULL, NULL, lg_xor_hash, (GrB_Matrix) v, x, GrB_DESC_T0)) ;
+    GRB_TRY (GrB_Scalar_extractElement_UINT64(hash, s)) ;
+    LG_FREE_ALL;
+    return GrB_SUCCESS;
+}

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -261,6 +261,14 @@ int LAGraph_Incidence_Matrix
 ) ;
 
 LAGRAPHX_PUBLIC
+int LAGraph_Hash_Vector
+(
+    uint64_t *hash,
+    GrB_Vector v,
+    char *msg
+) ;
+
+LAGRAPHX_PUBLIC
 int LAGraph_FastAssign_Monoid
 (
     // output


### PR DESCRIPTION
- Removed global arrays from SCC
- Cleaned up the code 
- Added some testing by hashing the result vector and checking it against the hash for previous results
- Added LAGraph_Hash_Matrix and LAGraph_Hash_Vector, which reduce UINT64 Matricies down to a uint64 regardless of storage method